### PR TITLE
feat: support passing literal values in dsl

### DIFF
--- a/dagger/dsl/build.py
+++ b/dagger/dsl/build.py
@@ -10,7 +10,7 @@ from dagger.dag import SupportedOutputs as SupportedDAGOutputs
 from dagger.dsl.context import node_invocations
 from dagger.dsl.errors import POTENTIAL_BUG_MESSAGE
 from dagger.dsl.node_invocation_recorder import NodeInvocationRecorder
-from dagger.dsl.node_invocations import NodeInvocation, NodeType, SupportedNodeInput
+from dagger.dsl.node_invocations import NodeInputReference, NodeInvocation, NodeType
 from dagger.dsl.node_outputs import (
     NodeOutputKeyUsage,
     NodeOutputPropertyUsage,
@@ -36,7 +36,7 @@ def build(dag: NodeInvocationRecorder) -> DAG:
 
 def _build(
     build_func: Callable,
-    inputs_from_parent: Mapping[str, SupportedNodeInput],
+    inputs_from_parent: Mapping[str, NodeInputReference],
     parent_node_names_by_id: Mapping[str, str],
     runtime_options: Mapping[str, Any],
 ) -> DAG:
@@ -213,7 +213,7 @@ def _translate_invocation_ids_into_readable_names(
 
 
 def _build_node_input(
-    input_type: SupportedNodeInput,
+    input_type: NodeInputReference,
     node_names_by_id: Mapping[str, str],
 ) -> Union[FromParam, FromNodeOutput]:
     """

--- a/dagger/dsl/node_invocation_recorder.py
+++ b/dagger/dsl/node_invocation_recorder.py
@@ -2,11 +2,16 @@
 
 import inspect
 import uuid
-from typing import Any, Callable, Mapping, Optional
+from typing import Any, Callable, Mapping, Optional, Sequence
 
 from dagger.dsl.context import node_invocations
 from dagger.dsl.errors import NodeInvokedWithMismatchedArgumentsError
-from dagger.dsl.node_invocations import NodeInvocation, NodeType, SupportedNodeInput
+from dagger.dsl.node_invocations import (
+    NodeInputReference,
+    NodeInvocation,
+    NodeType,
+    is_node_input_reference,
+)
 from dagger.dsl.node_outputs import NodeOutputUsage
 
 
@@ -52,8 +57,8 @@ class NodeInvocationRecorder:
             When some of the input/output types supported by dagger are not yet supported by the imperative DSL.
         """
         invocation_id = self._overridden_id or uuid.uuid4().hex
-        inputs = self._bind_arguments(*args, **kwargs)
-        self._consume_node_output_references(inputs)
+        arguments = self._bind_arguments(*args, **kwargs)
+        self._consume_node_output_references(list(arguments.values()))
         output = NodeOutputUsage(invocation_id=invocation_id)
 
         invocations = node_invocations.get([])
@@ -62,8 +67,8 @@ class NodeInvocationRecorder:
                 id=invocation_id,
                 name=self._func.__name__.replace("_", "-"),
                 node_type=self._node_type,
-                func=self._func,
-                inputs=inputs,
+                func=self._func_with_preset_params(arguments),
+                inputs=self._inputs(arguments),
                 output=output,
                 runtime_options=self._runtime_options,
             ),
@@ -87,7 +92,7 @@ class NodeInvocationRecorder:
         """Return the node type associated with this class."""
         return self._node_type
 
-    def _bind_arguments(self, *args, **kwargs) -> Mapping[str, SupportedNodeInput]:
+    def _bind_arguments(self, *args, **kwargs) -> Mapping[str, Any]:
         sig = inspect.signature(self._func)
 
         try:
@@ -99,16 +104,54 @@ class NodeInvocationRecorder:
 
         return bound_args.arguments
 
-    def _consume_node_output_references(self, inputs: Mapping[str, SupportedNodeInput]):
+    def _consume_node_output_references(self, arguments: Sequence[Any]):
         """
         Explicitly mark direct outputs from other nodes as consumed.
 
         This is only necessary for outputs of type NodeOutputUsage.
         See the documentation of the `.consume()` function to understand why.
         """
-        for i in inputs.values():
-            if isinstance(i, NodeOutputUsage):
-                i.consume()
+        for arg in arguments:
+            if isinstance(arg, NodeOutputUsage):
+                arg.consume()
+
+    def _func_with_preset_params(self, arguments: Mapping[str, Any]) -> Callable:
+        """
+        Return the function where all the arguments that come from a literal value (instead of a reference built by the DSL) are preset and don't need to be injected as a parameter anymore.
+
+        For instance, given:
+
+        ```
+        @dsl.task
+        def f(a, b, c):
+            pass
+
+        @dsl.DAG
+        def dsl(a):
+            f(a=a, b=2, c=3)
+        ```
+
+        This function would return a function f' so that f'(a) == f(a, 2, 3).
+        """
+        preset_params = {}
+        for argument_name, argument_value in arguments.items():
+            if not is_node_input_reference(argument_value):
+                preset_params[argument_name] = argument_value
+
+        if preset_params:
+            return lambda *args, **kwargs: self._func(
+                *args, **{**kwargs, **preset_params}
+            )
+
+        return self._func
+
+    def _inputs(self, arguments: Mapping[str, Any]) -> Mapping[str, NodeInputReference]:
+        """Filter the node input references that come as arguments to the node invocation."""
+        return {
+            argument_name: argument_value
+            for argument_name, argument_value in arguments.items()
+            if is_node_input_reference(argument_value)
+        }
 
     def __repr__(self) -> str:
         """Get a human-readable string representation of this object."""

--- a/dagger/dsl/node_invocations.py
+++ b/dagger/dsl/node_invocations.py
@@ -1,12 +1,12 @@
 """Data structures that hold information about certain elements being invoked or used throughout the definition of a DAG using the imperative DSL."""
 
 from enum import Enum
-from typing import Any, Callable, Mapping, NamedTuple, Optional, Union
+from typing import Any, Callable, Mapping, NamedTuple, Optional, Union, get_args
 
 from dagger.dsl.node_outputs import NodeOutputReference, NodeOutputUsage
 from dagger.dsl.parameter_usage import ParameterUsage
 
-SupportedNodeInput = Union[ParameterUsage, NodeOutputReference]
+NodeInputReference = Union[ParameterUsage, NodeOutputReference]
 
 
 class NodeType(Enum):
@@ -23,6 +23,16 @@ class NodeInvocation(NamedTuple):
     name: str
     node_type: NodeType
     func: Callable
-    inputs: Mapping[str, SupportedNodeInput]
+    inputs: Mapping[str, NodeInputReference]
     output: NodeOutputUsage
     runtime_options: Optional[Mapping[str, Any]] = None
+
+
+def is_node_input_reference(obj: Any):
+    """Return true if the supplied object is one of the supported node inputs."""
+    return any(
+        [
+            isinstance(obj, supported_type)
+            for supported_type in get_args(NodeInputReference)
+        ]
+    )

--- a/tests/dsl/test_black_box.py
+++ b/tests/dsl/test_black_box.py
@@ -82,6 +82,35 @@ def test__input_from_param():
     )
 
 
+def test__input_from_literal_value():
+    class ArbitraryObject:
+        pass
+
+    literal_values = [
+        "string literal",
+        2,
+        5.5,
+        True,
+        ["a", "list"],
+        {"complex": ArbitraryObject()},
+    ]
+
+    @dsl.task
+    def inspect(hello, value):
+        return f"{hello} {value} of type {type(value).__name__}"
+
+    @dsl.DAG
+    def dag(hello):
+        for value in literal_values:
+            inspect(hello="hello...", value=value)
+
+    for i, value in enumerate(literal_values):
+        assert (
+            dsl.build(dag).nodes[f"inspect-{i + 1}"].func()
+            == f"hello... {value} of type {type(value).__name__}"
+        )
+
+
 def test__input_from_param_with_different_names():
     @dsl.task
     def say_hello(first_name):


### PR DESCRIPTION
This PR extends the imperative DSL to support passing literal values alongside references to other parameters or outputs.

Put simply, it makes the following piece of code possible:

```python
@dsl.task
def f(a, b, c):
  return a + b + c

@dsl.DAG
def dag(a):
  o1 = f(a=1, b=2, c=3)
  o2 = f(a=o1, b=2, c=3)
  o3 = f(a=o1, b=o2, c=3)
  return f(a=o1, b=o2, c=o3)
```

Which would return:

```
o1 = 1+2+3 = 6
o2 = 6+2+3 = 11
o3 = 6+11+3 = 20
returns = 6+11+20 = 37
```