### PR TITLE
test: extend test coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ install:
 
 .PHONY: test
 test:
-	poetry run pytest --cov=dagger --cov-fail-under=95 --cov-report=xml
+	poetry run pytest --cov=dagger --cov-fail-under=98 --cov-report=xml
 
 .PHONY: lint
 lint:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Define sophisticated data pipelines and run them on different distributed systems (such as Argo Workflows).
 
-[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/larribas/dagger/blob/main/LICENSE.md) ![tests](https://github.com/larribas/dagger/actions/workflows/tests.yaml/badge.svg) ![documentation](https://github.com/larribas/dagger/actions/workflows/documentation.yaml/badge.svg) ![type system](https://github.com/larribas/dagger/actions/workflows/linting.yaml/badge.svg) ![style](https://github.com/larribas/dagger/actions/workflows/formatting.yaml/badge.svg)
+[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/larribas/dagger/blob/main/LICENSE.md) ![tests](https://github.com/larribas/dagger/actions/workflows/tests.yaml/badge.svg) [![codecov](https://codecov.io/gh/larribas/dagger/branch/main/graph/badge.svg?token=fKU68xYUm8)](https://codecov.io/gh/larribas/dagger) ![documentation](https://github.com/larribas/dagger/actions/workflows/documentation.yaml/badge.svg) ![type system](https://github.com/larribas/dagger/actions/workflows/linting.yaml/badge.svg) ![style](https://github.com/larribas/dagger/actions/workflows/formatting.yaml/badge.svg)
 
 ---
 

--- a/dagger/dag/dag.py
+++ b/dagger/dag/dag.py
@@ -176,14 +176,7 @@ class DAG:
 
     def __repr__(self) -> str:
         """Return a human-readable representation of the DAG."""
-        return f"""DAG(
-            inputs={self._inputs}, 
-            outputs={self._outputs}, 
-            runtime_options={self._runtime_options}, 
-            partition_by_input={self._partition_by_input},
-            nodes={self._nodes},
-        )
-        """
+        return f"DAG(inputs={self._inputs}, outputs={self._outputs}, runtime_options={self._runtime_options}, partition_by_input={self._partition_by_input}, nodes={self._nodes})"
 
     def __eq__(self, obj) -> bool:
         """Return true if the two DAGs are equivalent to each other."""

--- a/dagger/dag/dag.py
+++ b/dagger/dag/dag.py
@@ -284,31 +284,41 @@ def _validate_node_input_dependencies(
     dag_nodes: Mapping[str, Node],
     dag_inputs: Mapping[str, SupportedInputs],
 ):
-    for node_name in dag_nodes:
-        node = dag_nodes[node_name]
+    for node_name, node in dag_nodes.items():
         for input_name, input_type in node.inputs.items():
-            try:
-                if isinstance(input_type, FromParam):
-                    _validate_input_from_param(
-                        input_name=input_name,
-                        input_type=input_type,
-                        dag_inputs=dag_inputs,
-                    )
-                elif isinstance(input_type, FromNodeOutput):
-                    _validate_input_from_node_output(
-                        node_name=node_name,
-                        input_type=input_type,
-                        dag_nodes=dag_nodes,
-                    )
-                else:
-                    raise Exception(
-                        f"Whoops. The current version of the library doesn't seem to support inputs of type '{type(input_type)}'. This is most likely unintended. Please, check the GitHub project to see if this issue has already been reported and addressed in a newer version. Otherwise, please report this as a bug in our GitHub tracker. Sorry for the inconvenience."
-                    )
+            _validate_node_input_dependency(
+                node_name=node_name,
+                dag_nodes=dag_nodes,
+                dag_inputs=dag_inputs,
+                input_name=input_name,
+                input_type=input_type,
+            )
 
-            except (TypeError, ValueError) as e:
-                raise e.__class__(
-                    f"Error validating input '{input_name}' of node '{node_name}': {str(e)}"
-                )
+
+def _validate_node_input_dependency(
+    node_name: str,
+    dag_nodes: Mapping[str, Node],
+    dag_inputs: Mapping[str, SupportedInputs],
+    input_name: str,
+    input_type: Union[FromParam, FromNodeOutput],
+):
+    try:
+        if isinstance(input_type, FromParam):
+            _validate_input_from_param(
+                input_name=input_name,
+                input_type=input_type,
+                dag_inputs=dag_inputs,
+            )
+        else:
+            _validate_input_from_node_output(
+                node_name=node_name,
+                input_type=input_type,
+                dag_nodes=dag_nodes,
+            )
+    except (TypeError, ValueError) as e:
+        raise e.__class__(
+            f"Error validating input '{input_name}' of node '{node_name}': {str(e)}"
+        )
 
 
 def _validate_input_from_param(

--- a/dagger/data_structures/frozen_mapping.py
+++ b/dagger/data_structures/frozen_mapping.py
@@ -84,5 +84,4 @@ class FrozenMapping(Generic[K, V], MappingABC):
 
     def __repr__(self) -> str:
         """Get a human-readable string representation of the data structure."""
-        items = ", ".join([f"{k}: {v}" for k, v in self._mapping.items()])
-        return "{" + items + "}"
+        return repr(self._mapping)

--- a/dagger/dsl/node_invocation_recorder.py
+++ b/dagger/dsl/node_invocation_recorder.py
@@ -97,11 +97,6 @@ class NodeInvocationRecorder:
         """Return the runtime options associated with this class."""
         return self._runtime_options
 
-    @property
-    def node_type(self) -> NodeType:
-        """Return the node type associated with this class."""
-        return self._node_type
-
     def _bind_arguments(self, *args, **kwargs) -> Mapping[str, Any]:
         sig = inspect.signature(self._func)
 
@@ -205,7 +200,7 @@ class NodeInvocationRecorder:
 
     def __repr__(self) -> str:
         """Get a human-readable string representation of this object."""
-        return f"NodeInvocationRecorder(func={self._func}, node_type={self._node_type}, overridden_id={self._overridden_id}, runtime_options={self._runtime_options})"
+        return f"NodeInvocationRecorder(func={self._func}, node_type={self._node_type.value}, overridden_id={self._overridden_id}, runtime_options={self._runtime_options})"
 
     def __eq__(self, obj) -> bool:
         """Return true if both objects are equivalent."""

--- a/dagger/dsl/node_output_property_usage.py
+++ b/dagger/dsl/node_output_property_usage.py
@@ -79,7 +79,7 @@ class NodeOutputPropertyUsage:
 
     def __repr__(self) -> str:
         """Get a human-readable string representation of this instance."""
-        return f"NodeOutputKeyUsage(invocation_id={self._invocation_id}, output_name={self._output_name}, property_name={self._property_name}, serializer={self._serializer}, is_partitioned={self._is_partitioned}, references_node_partition={self._references_node_partition})"
+        return f"NodeOutputPropertyUsage(invocation_id={self._invocation_id}, output_name={self._output_name}, property_name={self._property_name}, serializer={self._serializer}, is_partitioned={self._is_partitioned}, references_node_partition={self._references_node_partition})"
 
     def __eq__(self, obj) -> bool:
         """Return true if both objects are equivalent."""

--- a/dagger/dsl/node_output_reference.py
+++ b/dagger/dsl/node_output_reference.py
@@ -6,7 +6,7 @@ from dagger.serializer import Serializer
 
 
 @runtime_checkable
-class NodeOutputReference(Protocol):
+class NodeOutputReference(Protocol):  # pragma: no cover
     """
     Protocol that references a specific output of a node.
 

--- a/dagger/output/from_key.py
+++ b/dagger/output/from_key.py
@@ -13,7 +13,7 @@ class FromKey(Generic[K, V]):
 
     def __init__(
         self,
-        key: K,
+        name: K,
         serializer: Serializer = DefaultSerializer,
         is_partitioned: bool = False,
     ):
@@ -22,7 +22,7 @@ class FromKey(Generic[K, V]):
 
         Parameters
         ----------
-        key
+        name
             Name of the key that contains the output.
 
         serializer
@@ -32,7 +32,7 @@ class FromKey(Generic[K, V]):
         is_partitioned
             A flag indicating whether this output should be partitioned. Partitioned outputs are assumed to come from an Iterable object. Each item in the Iterable should be serializable with the specified serializer.
         """
-        self._key = key
+        self._name = name
         self._serializer = serializer
         self._is_partitioned = is_partitioned
 
@@ -71,24 +71,24 @@ class FromKey(Generic[K, V]):
         """
         if isinstance(return_value, Mapping):
             try:
-                return return_value[self._key]
+                return return_value[self._name]
             except KeyError:
                 raise ValueError(
-                    f"An output of type {self.__class__.__name__}('{self._key}') expects the return value of the function to be a mapping containing, at least, a key named '{self._key}'"
+                    f"An output of type {self.__class__.__name__}('{self._name}') expects the return value of the function to be a mapping containing, at least, a key named '{self._name}'"
                 )
 
         raise TypeError(
-            f"This output is of type {self.__class__.__name__}. This means we expect the return value of the function to be a mapping containing, at least, a key named '{self._key}'"
+            f"This output is of type {self.__class__.__name__}. This means we expect the return value of the function to be a mapping containing, at least, a key named '{self._name}'"
         )
 
     def __repr__(self) -> str:
         """Get a human-readable string representation of the output."""
-        return f"FromKey(key={self._key}, serializer={self._serializer})"
+        return f"FromKey(key={self._name}, serializer={self._serializer}, is_partitioned={self._is_partitioned})"
 
     def __eq__(self, obj) -> bool:
         """Return true if both outputs are equivalent."""
         return (
             isinstance(obj, FromKey)
             and self._serializer == obj._serializer
-            and self._key == obj._key
+            and self._name == obj._name
         )

--- a/dagger/output/from_property.py
+++ b/dagger/output/from_property.py
@@ -69,7 +69,7 @@ class FromProperty:
 
     def __repr__(self) -> str:
         """Get a human-readable string representation of the output."""
-        return f"FromProperty(name={self._name}, serializer={self._serializer})"
+        return f"FromProperty(name={self._name}, serializer={self._serializer}, is_partitioned={self._is_partitioned})"
 
     def __eq__(self, obj) -> bool:
         """Return true if both outputs are equivalent."""

--- a/dagger/output/from_return_value.py
+++ b/dagger/output/from_return_value.py
@@ -50,4 +50,4 @@ class FromReturnValue(Generic[T]):
 
     def __repr__(self) -> str:
         """Return a human-readable representation of the output."""
-        return f"FromReturnValue(serializer={self._serializer})"
+        return f"FromReturnValue(serializer={self._serializer}, is_partitioned={self._is_partitioned})"

--- a/dagger/output/protocol.py
+++ b/dagger/output/protocol.py
@@ -6,7 +6,7 @@ from dagger.serializer import Serializer
 
 
 @runtime_checkable
-class Output(Protocol):
+class Output(Protocol):  # pragma: no cover
     """
     Protocol all outputs conform to.
 

--- a/dagger/runtime/argo/workflow_spec.py
+++ b/dagger/runtime/argo/workflow_spec.py
@@ -360,6 +360,7 @@ def _dag_task_with_param(
     Spec: https://argoproj.github.io/argo-workflows/fields/#dagtask
     """
     if isinstance(input_type, FromParam):
+        # As of version 1.0.0, this is not a valid map-reduce pattern and this should never happen
         return "{{" + f"workflow.parameters.{input_type.name or input_name}" + "}}"
     else:
         return (

--- a/dagger/runtime/local/dag.py
+++ b/dagger/runtime/local/dag.py
@@ -88,11 +88,7 @@ def _invoke_dag(
             ) from e
 
     dag_outputs = {
-        output_name: _dag_output(
-            output_name=output_name,
-            output_type=output_type,
-            outputs=outputs,
-        )
+        output_name: outputs[output_type.node][output_type.output]
         for output_name, output_type in dag.outputs.items()
     }
 
@@ -162,16 +158,3 @@ def _node_param_from_output(
         return PartitionedOutput(map(lambda v: serializer.deserialize(v), node_output))
     else:
         return serializer.deserialize(node_output)
-
-
-def _dag_output(
-    output_name: str,
-    output_type: FromNodeOutput,
-    outputs: Mapping[str, NodeOutputs],
-) -> NodeOutput:
-    if isinstance(outputs[output_type.node], PartitionedOutput):
-        return PartitionedOutput(
-            map(lambda p: p[output_type.output], outputs[output_type.node])
-        )
-    else:
-        return outputs[output_type.node][output_type.output]

--- a/dagger/runtime/local/types.py
+++ b/dagger/runtime/local/types.py
@@ -10,6 +10,7 @@ class PartitionedOutput(Generic[T]):
 
     def __init__(self, iterable: Iterable[T]):
         """Build a partitioned output from an Iterable."""
+        self._iterable = iterable
         self._iterator = iter(iterable)
 
     def __iter__(self) -> Iterator[T]:
@@ -22,7 +23,7 @@ class PartitionedOutput(Generic[T]):
 
     def __repr__(self) -> str:
         """Return a human-readable representation of the partitioned output."""
-        return repr(self._iterator)
+        return repr(self._iterable)
 
 
 #: One of the outputs of a node, which may be partitioned

--- a/dagger/serializer/protocol.py
+++ b/dagger/serializer/protocol.py
@@ -4,7 +4,7 @@ from typing import Any, Protocol, runtime_checkable
 
 
 @runtime_checkable
-class Serializer(Protocol):
+class Serializer(Protocol):  # pragma: no cover
     """Protocol all serializers should conform to."""
 
     extension: str

--- a/dagger/task/task.py
+++ b/dagger/task/task.py
@@ -137,14 +137,7 @@ class Task:
 
     def __repr__(self) -> str:
         """Return a human-readable representation of the task."""
-        return f"""Task(
-            task={self._func},
-            inputs={self._inputs}, 
-            outputs={self._outputs}, 
-            runtime_options={self._runtime_options}, 
-            partition_by_input={self._partition_by_input},
-        )
-        """
+        return f"Task(func={self._func}, inputs={self._inputs}, outputs={self._outputs}, runtime_options={self._runtime_options}, partition_by_input={self._partition_by_input})"
 
 
 def _validate_input_is_supported(input_name, input_type):

--- a/tests/dag/test_dag.py
+++ b/tests/dag/test_dag.py
@@ -514,6 +514,27 @@ def test__eq():
     assert all(x != y for x, y in combinations(different, 2))
 
 
+def test__representation():
+    def f(a):
+        pass
+
+    input_a = FromNodeOutput("another-node", "another-output")
+    output_b = FromNodeOutput("t", "o")
+    task = Task(lambda: 1, outputs={"o": FromReturnValue()})
+    dag = DAG(
+        inputs={"a": input_a},
+        outputs={"b": output_b},
+        nodes={"t": task},
+        runtime_options={"my": "options"},
+        partition_by_input="a",
+    )
+
+    assert (
+        repr(dag)
+        == f"DAG(inputs={{'a': {input_a}}}, outputs={{'b': {output_b}}}, runtime_options={{'my': 'options'}}, partition_by_input=a, nodes={{'t': {task}}})"
+    )
+
+
 #
 # validate_parameters
 #

--- a/tests/data_structures/test_frozen_mapping.py
+++ b/tests/data_structures/test_frozen_mapping.py
@@ -56,3 +56,8 @@ def test__equality():
 def test__equality_towards_other_types_of_mapping():
     a = FrozenMapping({"a": 1, "b": 2}, error_message="")
     assert a == {"a": 1, "b": 2}
+
+
+def test__representation():
+    frozen_map = FrozenMapping({"a": 1, "b": 2}, error_message="my-error")
+    assert repr(frozen_map) == "{'a': 1, 'b': 2}"

--- a/tests/dsl/test_build.py
+++ b/tests/dsl/test_build.py
@@ -2,6 +2,7 @@ import pytest
 
 from dagger.dsl.build import (
     _build_dag_outputs,
+    _build_from_parent,
     _build_node,
     _build_node_input,
     _build_task_output,
@@ -286,3 +287,31 @@ def test__build_dag_outputs__consumes_node_output_usages():
         node_names_by_id={"id": "name"},
     )
     assert node_output_usage.references == {node_output_usage}
+
+
+#
+# build_from_parent
+#
+
+
+def test__build_from_parent__when_node_type_is_not_dag():
+    with pytest.raises(TypeError) as e:
+        _build_from_parent(
+            invocation=NodeInvocation(
+                id="my-id",
+                name="my-name",
+                node_type=NodeType.TASK,
+                func=lambda: 1,
+                inputs={},
+                output=NodeOutputUsage(
+                    "my-id",
+                    serialize_annotation=Serialize(),
+                ),
+            ),
+            parent_node_names_by_id={},
+        )
+
+    assert (
+        str(e.value)
+        == "The DAGBuilder may only be instantiated from a NodeInvocation object with NodeType.DAG"
+    )

--- a/tests/dsl/test_build.py
+++ b/tests/dsl/test_build.py
@@ -1,3 +1,5 @@
+import pytest
+
 from dagger.dsl.build import (
     _build_dag_outputs,
     _build_node,
@@ -7,6 +9,8 @@ from dagger.dsl.build import (
 )
 from dagger.dsl.node_invocations import NodeInvocation, NodeType
 from dagger.dsl.node_output_key_usage import NodeOutputKeyUsage
+from dagger.dsl.node_output_partition_fan_in import NodeOutputPartitionFanIn
+from dagger.dsl.node_output_partition_usage import NodeOutputPartitionUsage
 from dagger.dsl.node_output_property_usage import NodeOutputPropertyUsage
 from dagger.dsl.node_output_usage import NodeOutputUsage
 from dagger.dsl.parameter_usage import ParameterUsage
@@ -50,6 +54,11 @@ def test__translate_invocation_ids_into_readable_names():
     }
 
 
+#
+# build_node_input
+#
+
+
 def test__build_node_input__param_usage():
     assert _build_node_input(ParameterUsage(), node_names_by_id={}) == FromParam()
     assert _build_node_input(
@@ -69,6 +78,11 @@ def test__build_node_input__node_output_reference():
         "return_value",
         serializer=AsPickle(),
     )
+
+
+#
+# build_task_output
+#
 
 
 def test__build_task_output__return_value():
@@ -108,6 +122,37 @@ def test__build_task_output__property():
         "prop",
         serializer=AsPickle(),
     )
+
+
+def test__build_task_output__partition_usage():
+    output_usage = NodeOutputUsage(
+        invocation_id="id",
+        serialize_annotation=Serialize(AsPickle()),
+    )
+    assert _build_task_output(
+        NodeOutputPartitionUsage(output_usage)
+    ) == FromReturnValue(serializer=AsPickle())
+
+
+def test__build_task_output__unsupported_reference():
+    output = NodeOutputPartitionFanIn(
+        NodeOutputUsage(
+            invocation_id="id",
+            serialize_annotation=Serialize(AsPickle()),
+        )
+    )
+    with pytest.raises(NotImplementedError) as e:
+        _build_task_output(output)
+
+    assert (
+        str(e.value)
+        == "The DSL is not compatible with node outputs of type 'NodeOutputPartitionFanIn'. If you are seeing this error, this is probably a bug in the library. Please check our GitHub repository to see whether the bug has already been reported/fixed. Otherwise, please create a ticket."
+    )
+
+
+#
+# build_node
+#
 
 
 def test__build_node__task():
@@ -164,6 +209,11 @@ def test__build_node__task():
             "property_prop": FromProperty("prop"),
         },
     )
+
+
+#
+# build_dag_outputs
+#
 
 
 def test__build_dag_outputs__when_none_are_returned():

--- a/tests/dsl/test_node_invocation_recorder.py
+++ b/tests/dsl/test_node_invocation_recorder.py
@@ -209,3 +209,19 @@ def test__task_invocation__with_a_partitioned_input():
         "x": x_output,
         "y": y_output,
     }
+
+
+def test__representation():
+    def my_func(x, y):
+        return x + y
+
+    recorder = NodeInvocationRecorder(
+        func=my_func,
+        node_type=NodeType.TASK,
+        override_id="my-id",
+    ).with_runtime_options({"my": "options"})
+
+    assert (
+        repr(recorder)
+        == f"NodeInvocationRecorder(func={my_func}, node_type=task, overridden_id=my-id, runtime_options={{'my': 'options'}})"
+    )

--- a/tests/dsl/test_node_output_key_usage.py
+++ b/tests/dsl/test_node_output_key_usage.py
@@ -45,3 +45,35 @@ def test__node_output_key_usage__is_iterable():
     # When we iterate over it
     assert list(output) == [NodeOutputPartitionUsage(output)]
     assert output.is_partitioned is True
+
+
+def test__node_output_key_usage__representation():
+    serializer = AsPickle()
+    output = NodeOutputKeyUsage(
+        invocation_id="x",
+        output_name="y",
+        key_name="z",
+        serializer=serializer,
+        references_node_partition=True,
+    )
+    assert (
+        repr(output)
+        == f"NodeOutputKeyUsage(invocation_id=x, output_name=y, key_name=z, serializer={serializer}, is_partitioned=False, references_node_partition=True)"
+    )
+
+
+def test__node_output_key_usage__consume_does_nothing():
+    a = NodeOutputKeyUsage(
+        invocation_id="x",
+        output_name="y",
+        key_name="z",
+        serializer=DefaultSerializer,
+    )
+    b = NodeOutputKeyUsage(
+        invocation_id="x",
+        output_name="y",
+        key_name="z",
+        serializer=DefaultSerializer,
+    )
+    b.consume()
+    assert a == b

--- a/tests/dsl/test_node_output_partition_fan_in.py
+++ b/tests/dsl/test_node_output_partition_fan_in.py
@@ -1,3 +1,5 @@
+import pytest
+
 from dagger.dsl.node_output_partition_fan_in import NodeOutputPartitionFanIn
 from dagger.dsl.node_output_reference import NodeOutputReference
 from dagger.dsl.node_output_usage import NodeOutputUsage
@@ -27,3 +29,33 @@ def test__node_output_partition_fan_in__properties():
     assert output_partition.is_partitioned is False
     assert output_partition.references_node_partition is False
     assert output_partition.wrapped_reference == output
+
+
+def test__representation():
+    output = NodeOutputUsage(
+        invocation_id="x",
+        serialize_annotation=Serialize(),
+    )
+    output_partition = NodeOutputPartitionFanIn(output)
+    assert (
+        repr(output_partition)
+        == f"NodeOutputPartitionFanIn(wrapped_reference={output})"
+    )
+
+
+def test__eq():
+    output = NodeOutputUsage(
+        invocation_id="x",
+        serialize_annotation=Serialize(),
+    )
+    assert NodeOutputPartitionFanIn(output) == NodeOutputPartitionFanIn(output)
+
+
+def test__iter():
+    output = NodeOutputUsage(
+        invocation_id="x",
+        serialize_annotation=Serialize(),
+    )
+
+    with pytest.raises(NotImplementedError):
+        iter(NodeOutputPartitionFanIn(output))

--- a/tests/dsl/test_node_output_partition_usage.py
+++ b/tests/dsl/test_node_output_partition_usage.py
@@ -34,6 +34,18 @@ def test__node_output_partition_usage__properties():
     assert output_partition.wrapped_reference == output
 
 
+def test__node_output_partition_usage__representation():
+    output = NodeOutputUsage(
+        invocation_id="x",
+        serialize_annotation=Serialize(),
+    )
+    output_partition = NodeOutputPartitionUsage(output)
+    assert (
+        repr(output_partition)
+        == f"NodeOutputPartitionUsage(wrapped_reference={output})"
+    )
+
+
 def test__node_output_partition_usage__is_iterable_but_cannot_be_iterated_over():
     output = NodeOutputPartitionUsage(
         NodeOutputUsage(

--- a/tests/dsl/test_node_output_property_usage.py
+++ b/tests/dsl/test_node_output_property_usage.py
@@ -45,3 +45,35 @@ def test__node_output_property_usage__is_iterable():
     # When we iterate over it
     assert list(output) == [NodeOutputPartitionUsage(output)]
     assert output.is_partitioned is True
+
+
+def test__node_output_property_usage__representation():
+    serializer = AsPickle()
+    output = NodeOutputPropertyUsage(
+        invocation_id="x",
+        output_name="y",
+        property_name="z",
+        serializer=serializer,
+        references_node_partition=True,
+    )
+    assert (
+        repr(output)
+        == f"NodeOutputPropertyUsage(invocation_id=x, output_name=y, property_name=z, serializer={serializer}, is_partitioned=False, references_node_partition=True)"
+    )
+
+
+def test__node_output_property_usage__consume_does_nothing():
+    a = NodeOutputPropertyUsage(
+        invocation_id="x",
+        output_name="y",
+        property_name="z",
+        serializer=DefaultSerializer,
+    )
+    b = NodeOutputPropertyUsage(
+        invocation_id="x",
+        output_name="y",
+        property_name="z",
+        serializer=DefaultSerializer,
+    )
+    b.consume()
+    assert a == b

--- a/tests/dsl/test_node_output_usage.py
+++ b/tests/dsl/test_node_output_usage.py
@@ -132,3 +132,11 @@ def test__node_output_usage__is_iterable():
     assert list(output) == [NodeOutputPartitionUsage(output)]
     assert output.is_partitioned is True
     assert output.references == {output}
+
+
+def test__node_output_usage__representation():
+    output = NodeOutputUsage(
+        invocation_id="x",
+        serialize_annotation=Serialize(),
+    )
+    assert repr(output) == "NodeOutputUsage(invocation_id=x)"

--- a/tests/dsl/test_serialize.py
+++ b/tests/dsl/test_serialize.py
@@ -38,6 +38,21 @@ def test__serialize__multiple_sub_outputs_omitting_root():
     assert serialize.sub_output("missing") is None
 
 
+def test__serialize__representation():
+    root_serializer = AsPickle()
+    a_serializer = AsJSON(indent=1)
+    b_serializer = AsJSON(indent=3)
+    serialize = Serialize(
+        root=root_serializer,
+        a=a_serializer,
+        b=b_serializer,
+    )
+    assert (
+        repr(serialize)
+        == f"Serialize(root={root_serializer}, a={a_serializer}, b={b_serializer})"
+    )
+
+
 #
 # find_serialize_annotation
 #

--- a/tests/input/custom_serializer.py
+++ b/tests/input/custom_serializer.py
@@ -13,3 +13,6 @@ class CustomSerializer:
 
     def deserialize(self, serialized_value: bytes) -> str:  # noqa
         return "deserialized"
+
+    def __repr__(self) -> str:  # noqa
+        return "CustomSerializerInstance"

--- a/tests/input/test_from_node_output.py
+++ b/tests/input/test_from_node_output.py
@@ -11,16 +11,26 @@ def test__conforms_to_protocol():
 def test__exposes_node_and_output_name():
     node_name = "another-node"
     output_name = "another-nodes-output"
-    input = FromNodeOutput(node=node_name, output=output_name)
-    assert input.node == node_name
-    assert input.output == output_name
+    input_ = FromNodeOutput(node=node_name, output=output_name)
+    assert input_.node == node_name
+    assert input_.output == output_name
 
 
 def test__with_default_serializer():
-    input = FromNodeOutput("node", "output")
-    assert input.serializer == DefaultSerializer
+    input_ = FromNodeOutput("node", "output")
+    assert input_.serializer == DefaultSerializer
 
 
 def test__with_custom_serializer():
-    input = FromNodeOutput("node", "output", serializer=CustomSerializer)
-    assert input.serializer == CustomSerializer
+    serializer = CustomSerializer()
+    input_ = FromNodeOutput("node", "output", serializer=serializer)
+    assert input_.serializer == serializer
+
+
+def test__representation():
+    serializer = CustomSerializer()
+    input_ = FromNodeOutput("my-node", "my-output", serializer=serializer)
+    assert (
+        repr(input_)
+        == f"FromNodeOutput(node=my-node, output=my-output, serializer={repr(serializer)})"
+    )

--- a/tests/input/test_from_param.py
+++ b/tests/input/test_from_param.py
@@ -9,21 +9,28 @@ def test__conforms_to_protocol():
 
 
 def test__with_default_serializer():
-    input = FromParam()
-    assert input.serializer == DefaultSerializer
+    input_ = FromParam()
+    assert input_.serializer == DefaultSerializer
 
 
 def test__with_custom_serializer():
-    input = FromParam(serializer=CustomSerializer)
-    assert input.serializer == CustomSerializer
+    serializer = CustomSerializer()
+    input_ = FromParam(serializer=serializer)
+    assert input_.serializer == serializer
 
 
 def test__with_default_name():
-    input = FromParam()
-    assert input.name is None
+    input_ = FromParam()
+    assert input_.name is None
 
 
 def test__with_overridden_name():
     name = "custom-name"
-    input = FromParam(name)
-    assert input.name == name
+    input_ = FromParam(name)
+    assert input_.name == name
+
+
+def test__representation():
+    serializer = CustomSerializer()
+    input_ = FromParam("my-param", serializer=serializer)
+    assert repr(input_) == f"FromParam(name=my-param, serializer={repr(serializer)})"

--- a/tests/output/test_from_key.py
+++ b/tests/output/test_from_key.py
@@ -2,21 +2,25 @@ import pytest
 
 from dagger.output.from_key import FromKey
 from dagger.output.protocol import Output
-from dagger.serializer import DefaultSerializer
+from dagger.serializer import AsPickle, DefaultSerializer
 
 
 def test__conforms_to_protocol():
     assert isinstance(FromKey("x"), Output)
 
 
-#
-# Init
-#
+def test__serializer():
+    custom_serializer = AsPickle()
+    assert FromKey("key-name").serializer == DefaultSerializer
+    assert (
+        FromKey("key-name", serializer=custom_serializer).serializer
+        == custom_serializer
+    )
 
 
-def test__init__with_default_serializer():
-    output = FromKey("key-name")
-    assert output.serializer == DefaultSerializer
+def test__is_partitioned():
+    assert FromKey("key-name").is_partitioned is False
+    assert FromKey("key-name", is_partitioned=True).is_partitioned is True
 
 
 #
@@ -53,4 +57,17 @@ def test__from_function_return_value__with_unsupported_type():
     assert (
         str(e.value)
         == "This output is of type FromKey. This means we expect the return value of the function to be a mapping containing, at least, a key named 'x'"
+    )
+
+
+def test__representation():
+    serializer = AsPickle()
+    output = FromKey(
+        "my-key",
+        serializer=serializer,
+        is_partitioned=True,
+    )
+    assert (
+        repr(output)
+        == f"FromKey(key=my-key, serializer={repr(serializer)}, is_partitioned=True)"
     )

--- a/tests/output/test_from_property.py
+++ b/tests/output/test_from_property.py
@@ -4,21 +4,25 @@ import pytest
 
 from dagger.output.from_property import FromProperty
 from dagger.output.protocol import Output
-from dagger.serializer import DefaultSerializer
+from dagger.serializer import AsPickle, DefaultSerializer
 
 
 def test__conforms_to_protocol():
     assert isinstance(FromProperty("x"), Output)
 
 
-#
-# Init
-#
+def test__serializer():
+    custom_serializer = AsPickle()
+    assert FromProperty("property-name").serializer == DefaultSerializer
+    assert (
+        FromProperty("property-name", serializer=custom_serializer).serializer
+        == custom_serializer
+    )
 
 
-def test__init__with_default_serializer():
-    output = FromProperty("property-name")
-    assert output.serializer == DefaultSerializer
+def test__is_partitioned():
+    assert FromProperty("property-name").is_partitioned is False
+    assert FromProperty("property-name", is_partitioned=True).is_partitioned is True
 
 
 #
@@ -47,4 +51,17 @@ def test__from_function_return_value__with_missing_property():
     assert (
         str(e.value)
         == "This output is of type FromProperty. This means we expect the return value of the function to be an object with a property named 'x'"
+    )
+
+
+def test__representation():
+    serializer = AsPickle()
+    output = FromProperty(
+        "my-property",
+        serializer=serializer,
+        is_partitioned=True,
+    )
+    assert (
+        repr(output)
+        == f"FromProperty(name=my-property, serializer={repr(serializer)}, is_partitioned=True)"
     )

--- a/tests/output/test_from_return_value.py
+++ b/tests/output/test_from_return_value.py
@@ -1,20 +1,21 @@
 from dagger.output.from_return_value import FromReturnValue
 from dagger.output.protocol import Output
-from dagger.serializer import DefaultSerializer
+from dagger.serializer import AsPickle, DefaultSerializer
 
 
 def test__conforms_to_protocol():
     assert isinstance(FromReturnValue(), Output)
 
 
-#
-# Init
-#
+def test__serializer():
+    custom_serializer = AsPickle()
+    assert FromReturnValue().serializer == DefaultSerializer
+    assert FromReturnValue(serializer=custom_serializer).serializer == custom_serializer
 
 
-def test__init__with_default_serializer():
-    output = FromReturnValue()
-    assert output.serializer == DefaultSerializer
+def test__is_partitioned():
+    assert FromReturnValue().is_partitioned is False
+    assert FromReturnValue(is_partitioned=True).is_partitioned is True
 
 
 #
@@ -34,3 +35,15 @@ def test__from_function_return_value__is_the_identity_function():
 
     for return_value in return_values:
         assert output.from_function_return_value(return_value) == return_value
+
+
+def test__representation():
+    serializer = AsPickle()
+    output = FromReturnValue(
+        serializer=serializer,
+        is_partitioned=True,
+    )
+    assert (
+        repr(output)
+        == f"FromReturnValue(serializer={repr(serializer)}, is_partitioned=True)"
+    )

--- a/tests/runtime/argo/test_workflow_spec.py
+++ b/tests/runtime/argo/test_workflow_spec.py
@@ -3,7 +3,11 @@ import pytest
 from dagger.dag import DAG
 from dagger.input import FromNodeOutput, FromParam
 from dagger.output import FromReturnValue
-from dagger.runtime.argo.workflow_spec import Workflow, workflow_spec
+from dagger.runtime.argo.workflow_spec import (
+    Workflow,
+    _dag_task_with_param,
+    workflow_spec,
+)
 from dagger.task import Task
 
 #
@@ -449,3 +453,20 @@ def test__workflow_spec__with_workflow_spec_overrides():
             },
         ],
     }
+
+
+def test__dag_task_with_param():
+    assert (
+        _dag_task_with_param("my-input", FromParam("parent-input"))
+        == "{{workflow.parameters.parent-input}}"
+    )
+    assert (
+        _dag_task_with_param("my-input", FromParam())
+        == "{{workflow.parameters.my-input}}"
+    )
+    assert (
+        _dag_task_with_param(
+            "my-input", FromNodeOutput("another-node", "another-output")
+        )
+        == "{{tasks.another-node.outputs.parameters.another-output_partitions}}"
+    )

--- a/tests/runtime/cli/test_nested_nodes.py
+++ b/tests/runtime/cli/test_nested_nodes.py
@@ -129,3 +129,13 @@ def test__nodes_referenced_so_far__several_levels_of_nesting():
         )
         == ["b", "a"]
     )
+
+
+def test__node_with_parent__representation():
+    task = Task(lambda: 1)
+    dag = DAG({"a": task})
+    node_with_parent = find_nested_node(dag, ["a"])
+    assert (
+        repr(node_with_parent)
+        == f"NodeWithParent(node={repr(task)}, node_name=a, parent=NodeWithParent(node={repr(dag)}, node_name=, parent=None))"
+    )

--- a/tests/runtime/local/test_types.py
+++ b/tests/runtime/local/test_types.py
@@ -1,0 +1,22 @@
+from collections.abc import Iterable, Iterator
+
+import pytest
+
+from dagger.runtime.local.types import PartitionedOutput
+
+
+def test__partitioned_output__is_iterable():
+    output = PartitionedOutput([1, 2])
+    assert isinstance(output, Iterable)
+    assert isinstance(iter(output), Iterator)
+
+    i = iter(output)
+    assert next(i) == 1
+    assert next(i) == 2
+
+    with pytest.raises(StopIteration):
+        next(i)
+
+
+def test__partitioned_output__representation():
+    assert repr(PartitionedOutput([1, 2, 3])) == "[1, 2, 3]"

--- a/tests/task/test_task.py
+++ b/tests/task/test_task.py
@@ -220,3 +220,25 @@ def test__eq():
 
     assert all(x == y for x, y in combinations(same, 2))
     assert all(x != y for x, y in combinations(different, 2))
+
+
+def test__representation():
+    def f(a):
+        pass
+
+    input_a = FromNodeOutput("another-node", "another-output")
+    output_b = FromReturnValue()
+    task = Task(
+        f,
+        inputs={"a": input_a},
+        outputs={
+            "b": output_b,
+        },
+        runtime_options={"my": "options"},
+        partition_by_input="a",
+    )
+
+    assert (
+        repr(task)
+        == f"Task(func={f}, inputs={{'a': {input_a}}}, outputs={{'b': {output_b}}}, runtime_options={{'my': 'options'}}, partition_by_input=a)"
+    )


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please fill in the following template -->

#### What this PR does / why do we need it:

The purpose of this PR is to extend the test coverage for dagger, fix some issues detected by the lack of test coverage and verify that Codecov reports absolute and diff code coverage correctly.


#### Release Notes

<!--
Write a release note to be included with the release of the next version
-->
```release-note
Extended test coverage to ~99%
```

#### What type of changes to the API does this change introduce?

MAJOR: `FromKey` now accepts an attribute named `name` instead of `key`.


#### Checklist

- [x] I've read the [Contribution Guidelines](https://github.com/larribas/dagger/blob/main/CONTRIBUTING.md)
- [x] Updated the appropriate sections of the documentation.
- [x] I've added automated tests covering all success and error scenarios.
