### PR TITLE
chore: Rename to avoid pypi conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This section shows a couple of examples of what _Dagger_ is capable of. Our [off
 _Dagger_ is published to the Python Package Index (PyPI). To install it, you can simply run:
 
 ```
-pip install dagger
+pip install py-dagger
 ```
 
 

--- a/dagger/__init__.py
+++ b/dagger/__init__.py
@@ -6,6 +6,7 @@ import dagger.dsl as dsl  # noqa
 from dagger.dag import DAG  # noqa
 from dagger.task import Task  # noqa
 
+# We use dynamic versioning, coming from Git tags. 0.0.0 is a placeholder.
 __version__ = "0.0.0"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,18 +1,26 @@
 [tool.poetry]
 name = "py-dagger"
-version = "0.0.0"
+packages = [{ include = "dagger" }]
 description = "Define sophisticated data pipelines with Python and run them on different distributed systems (such as Argo Workflows)."
 authors = ["larribas <lorenzo.s.arribas@gmail.com>"]
+version = "0.0.0"
+license = "Apache-2.0"
+readme = "README.md"
+repository = "https://github.com/larribas/dagger"
+documentation = "https://dagger.readthedocs.io"
 keywords = [
-  "argo",
   "argo-workflows",
   "data-engineering",
   "data-pipelines",
-  "data-science",
-  "distributed-systems",
-  "pipelines",
-  "pipelines-as-code",
-  "workflows",
+  "data-science"
+]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Natural Language :: English",
+    "Programming Language :: Python :: 3 :: Only",
+    "Topic :: Software Development :: Build Tools"
 ]
 
 [tool.poetry.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,17 @@ name = "py-dagger"
 version = "0.0.0"
 description = "Define sophisticated data pipelines with Python and run them on different distributed systems (such as Argo Workflows)."
 authors = ["larribas <lorenzo.s.arribas@gmail.com>"]
+keywords = [
+  "argo",
+  "argo-workflows",
+  "data-engineering",
+  "data-pipelines",
+  "data-science",
+  "distributed-systems",
+  "pipelines",
+  "pipelines-as-code",
+  "workflows",
+]
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "dagger"
+name = "py-dagger"
 version = "0.0.0"
 description = "Define sophisticated data pipelines with Python and run them on different distributed systems (such as Argo Workflows)."
 authors = ["larribas <lorenzo.s.arribas@gmail.com>"]

--- a/tests/test_dagger.py
+++ b/tests/test_dagger.py
@@ -2,4 +2,4 @@ from dagger import __version__
 
 
 def test_version():
-    assert __version__ == "1.0.0"
+    assert __version__ == "0.0.0"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please fill in the following template -->

#### What this PR does / why do we need it:

This PR renames the project from `dagger` to `py-dagger` to avoid conflicts with an existing project named `dagger`.

Users will still import it as `import dagger`, but they will need to install it via `pip install py-dagger`.

Alternative names we considered were:
- larribas-dagger
- dag-ger


#### Release Notes

<!--
Write a release note to be included with the release of the next version
-->
```release-note
Renamed PyPi project to py-dagger to avoid conflicts with existing projects.
```

#### What type of changes to the API does this change introduce?

No user-facing changes to the API.


#### Checklist

- [x] I've read the [Contribution Guidelines](https://github.com/larribas/dagger/blob/main/CONTRIBUTING.md)
- [x] Updated the appropriate sections of the documentation.
- [x] I've added automated tests covering all success and error scenarios.
