### PR TITLE
chore: add specific codecov config

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,27 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "95...100"
+  status:
+   project:
+    default:
+      threshold: 0.5%
+  patch:
+    default:
+      threshold: 0.1%
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "reach,diff,flags,files,footer"
+  behavior: default
+  require_changes: no


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please fill in the following template -->

#### What this PR does / why do we need it:

This PR adds a `codecov.yml` file to explicitly set the thresholds upon which the project or patch GitHub checks fail, to avoid situations like the code failing for a drop of 0.01% (which happened recently due to a refactor that removed some code, making the overall impact of untested branches bigger).

#### Release Notes

<!--
Write a release note to be included with the release of the next version
-->
```release-note
Added CodeCov configuration
```

#### What type of changes to the API does this change introduce?

No user-facing changes.


#### Checklist

- [x] I've read the [Contribution Guidelines](https://github.com/larribas/dagger/blob/main/CONTRIBUTING.md)
- [x] Updated the appropriate sections of the documentation.
- [x] I've added automated tests covering all success and error scenarios.
