### PR TITLE
fix: stop exposing scripts through poetry

### DIFF
--- a/.github/workflows/argo-examples.yaml
+++ b/.github/workflows/argo-examples.yaml
@@ -40,17 +40,30 @@ jobs:
       - name: Install k3d
         run: |
           wget -q -O - https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=v4.4.4 bash
-      - name: Install Argo on k3d
+      - name: Set up k3d cluster
         run: |
-          make set-up-argo
+          make k3d-set-up
+      - name: Install Argo Workflows
+        run: |
+          echo "Waiting 1 minute until the cluster is stable"
+          sleep 60
+          kubectl get namespaces
+          kubectl get pods --all-namespaces
+          make k3d-install-argo
       - name: Package examples in Docker container and push to local registry
         run: |
-          make docker-push-local
-      - name: Run all examples with Argo and expect them to work
+          make k3d-docker-push
+      - name: Wait for Argo to be running correctly
         run: |
           echo "Verifying whether Argo is running correctly"
           kubectl get pods -n $(KUBE_NAMESPACE)
 
+          echo "Waiting 30 seconds for it to stabilize completely"
+          sleep 30
+          kubectl get pods -n $(KUBE_NAMESPACE)
+
+      - name: Run all examples with Argo and expect them to work
+        run: |
           EXAMPLES_DIR=tests/examples/argo/
           ls -l $EXAMPLES_DIR
           for f in $EXAMPLES_DIR/*.yaml; do

--- a/.github/workflows/argo-examples.yaml
+++ b/.github/workflows/argo-examples.yaml
@@ -47,6 +47,7 @@ jobs:
         run: |
           echo "Waiting 1 minute until the cluster is stable"
           sleep 60
+	        kubectl cluster-info
           kubectl get namespaces
           kubectl get pods --all-namespaces
           make k3d-install-argo

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ ci: lint check-types check-format check-docs test
 
 .PHONY: build
 build:
-	poetry build -f wheel
+	poetry build
 
 .PHONY: set-version-from-git
 set-version-from-git:
@@ -52,28 +52,24 @@ set-version-from-git:
 docker-build: build
 	docker build . -t $(DOCKER_IMAGE_NAME):$(VERSION) --build-arg "WHEEL=py_dagger-`poetry version -s`-py3-none-any.whl"
 
-.PHONY: docker-push-local
-docker-push-local: docker-build
+
+.PHONY: k3d-set-up
+k3d-set-up:
+	k3d registry create $(K3D_REGISTRY_NAME) --port $(K3D_REGISTRY_PORT)
+	k3d cluster create $(K3D_CLUSTER_NAME) --registry-use "k3d-$(K3D_REGISTRY_NAME):$(K3D_REGISTRY_PORT)" --registry-config k3d/registries.yaml --kubeconfig-update-default --kubeconfig-switch-context
+	kubectl cluster-info
+
+.PHONY: k3d-docker-push
+k3d-docker-push: docker-build
 	docker tag $(DOCKER_IMAGE_NAME):$(VERSION) localhost:$(K3D_REGISTRY_PORT)/$(DOCKER_IMAGE_NAME):$(VERSION)
 	docker push localhost:$(K3D_REGISTRY_PORT)/$(DOCKER_IMAGE_NAME):$(VERSION)
 
-.PHONY: run-%
-docker-run-%: build
-	docker run -it --entrypoint=$* $(DOCKER_IMAGE_NAME):$(VERSION)
-
-.PHONY: set-up-argo
-set-up-argo:
-	k3d registry create $(K3D_REGISTRY_NAME) --port $(K3D_REGISTRY_PORT)
-	k3d cluster create $(K3D_CLUSTER_NAME) --registry-use "k3d-$(K3D_REGISTRY_NAME):$(K3D_REGISTRY_PORT)" --registry-config k3d/registries.yaml --kubeconfig-update-default --kubeconfig-switch-context
-	echo "Waiting for a while for the cluster and the namespace to stabilize"
-	sleep 10
-	kubectl cluster-info
-	kubectl config use-context k3d-dagger
-	kubectl cluster-info
+.PHONY: k3d-install-argo
+k3d-install-argo:
 	kubectl create ns $(KUBE_NAMESPACE)
 	kubectl apply -n $(KUBE_NAMESPACE) -k tests/e2e/manifests/argo
 
-.PHONY: tear-down-argo
-tear-down-argo:
+.PHONY: k3d-tear-down
+k3d-tear-down:
 	k3d registry delete k3d-$(K3D_REGISTRY_NAME)
 	k3d cluster delete $(K3D_CLUSTER_NAME)

--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,9 @@ set-up-argo:
 	k3d cluster create $(K3D_CLUSTER_NAME) --registry-use "k3d-$(K3D_REGISTRY_NAME):$(K3D_REGISTRY_PORT)" --registry-config k3d/registries.yaml --kubeconfig-update-default --kubeconfig-switch-context
 	echo "Waiting for a while for the cluster and the namespace to stabilize"
 	sleep 10
+	kubectl cluster-info
+	kubectl config use-context k3d-dagger
+	kubectl cluster-info
 	kubectl create ns $(KUBE_NAMESPACE)
 	kubectl apply -n $(KUBE_NAMESPACE) -k tests/e2e/manifests/argo
 

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,6 @@ docker-build: build
 k3d-set-up:
 	k3d registry create $(K3D_REGISTRY_NAME) --port $(K3D_REGISTRY_PORT)
 	k3d cluster create $(K3D_CLUSTER_NAME) --registry-use "k3d-$(K3D_REGISTRY_NAME):$(K3D_REGISTRY_PORT)" --registry-config k3d/registries.yaml --kubeconfig-update-default --kubeconfig-switch-context
-	kubectl cluster-info
 
 .PHONY: k3d-docker-push
 k3d-docker-push: docker-build

--- a/Makefile
+++ b/Makefile
@@ -45,12 +45,12 @@ build:
 set-version-from-git:
 	@echo "Version will be $$(git describe --tags --abbrev=0)"
 	poetry version $$(git describe --tags --abbrev=0)
-	sed -i 's/0.0.0/$$(git describe --tags --abbrev=0)/' dagger/__init__.py
+	sed -i "s/0.0.0/$$(git describe --tags --abbrev=0)/" dagger/__init__.py
 	cat dagger/__init__.py
 
 .PHONY: docker-build
 docker-build: build
-	docker build . -t $(DOCKER_IMAGE_NAME):$(VERSION) --build-arg "WHEEL=dagger-`poetry version -s`-py3-none-any.whl"
+	docker build . -t $(DOCKER_IMAGE_NAME):$(VERSION) --build-arg "WHEEL=py_dagger-`poetry version -s`-py3-none-any.whl"
 
 .PHONY: docker-push-local
 docker-push-local: docker-build

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ We use Poetry to manage the dependencies of this library. In the codebase, you w
 - `make ci` - Run all the quality checks we run for each commit/PR. This includes type hint checking, linting, formatting and documentation.
 - `make build` - Build the project's WHEEL
 - `make docker-build` - Package the project in a Docker image
-- `make docker-run-example-name` - Run any example DAG of those defined in "dagger/examples" (for instance, `make run-hello-world`)
-- `make set-up-argo` - Create a k3d cluster for the project and installs Argo 3.0 in it. It also sets up a k3d image registry so that you can run the examples remotely.
-- `make docker-push-local` - Build and push the project's Docker image to the local k3d registry.
-- `make tear-down-argo` - Destroy the k3d cluster and registry where we deployed Argo.
+- `make k3d-set-up` - Create a k3d cluster and image registry for the project.
+- `make k3d-docker-push` - Build and push the project's Docker image to the local k3d registry.
+- `make k3d-install-argo` - Install Argo on k3d, for local testing of Argo Workflows.
+- `make k3d-tear-down` - Destroy the k3d cluster and registry.

--- a/examples/argo_specific_extras.py
+++ b/examples/argo_specific_extras.py
@@ -35,7 +35,7 @@ dag = DAG(
 )
 
 
-def run_from_cli():
+if __name__ == "__main__":
     """Define a command-line interface for this DAG, using the CLI runtime. Check the documentation to understand why this is relevant or necessary."""
     from dagger.runtime.cli import invoke
 

--- a/examples/composite_map_reduce.py
+++ b/examples/composite_map_reduce.py
@@ -47,7 +47,7 @@ def dag(partitions, exponent):
     )
 
 
-def run_from_cli():
+if __name__ == "__main__":
     """Define a command-line interface for this DAG, using the CLI runtime. Check the documentation to understand why this is relevant or necessary."""
     from dagger.runtime.cli import invoke
 

--- a/examples/hello_world.py
+++ b/examples/hello_world.py
@@ -17,7 +17,7 @@ dag = DAG(
 )
 
 
-def run_from_cli():
+if __name__ == "__main__":
     """Define a command-line interface for this DAG, using the CLI runtime. Check the documentation to understand why this is relevant or necessary."""
     from dagger.runtime.cli import invoke
 

--- a/examples/map_reduce.py
+++ b/examples/map_reduce.py
@@ -93,7 +93,7 @@ dag = DAG(
 )
 
 
-def run_from_cli():
+if __name__ == "__main__":
     """Define a command-line interface for this DAG, using the CLI runtime. Check the documentation to understand why this is relevant or necessary."""
     from dagger.runtime.cli import invoke
 

--- a/examples/nested_dags.py
+++ b/examples/nested_dags.py
@@ -133,7 +133,7 @@ dag = DAG(
 )
 
 
-def run_from_cli():
+if __name__ == "__main__":
     """Define a command-line interface for this DAG, using the CLI runtime. Check the documentation to understand why this is relevant or necessary."""
     from dagger.runtime.cli import invoke
 

--- a/examples/nested_map_reduce.py
+++ b/examples/nested_map_reduce.py
@@ -95,7 +95,7 @@ dag = DAG(
 )
 
 
-def run_from_cli():
+if __name__ == "__main__":
     """Define a command-line interface for this DAG, using the CLI runtime. Check the documentation to understand why this is relevant or necessary."""
     from dagger.runtime.cli import invoke
 

--- a/examples/passing_parameters.py
+++ b/examples/passing_parameters.py
@@ -75,7 +75,7 @@ dag = DAG(
 )
 
 
-def run_from_cli():
+if __name__ == "__main__":
     """Define a command-line interface for this DAG, using the CLI runtime. Check the documentation to understand why this is relevant or necessary."""
     from dagger.runtime.cli import invoke
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,11 +49,3 @@ multi_line_output = 3
 inherit = false
 convention = "numpy"
 
-[tool.poetry.scripts]
-hello-world = "examples.hello_world:run_from_cli"
-passing-parameters = "examples.passing_parameters:run_from_cli"
-map-reduce = "examples.map_reduce:run_from_cli"
-nested-map-reduce = "examples.nested_map_reduce:run_from_cli"
-composite-map-reduce = "examples.composite_map_reduce:run_from_cli"
-nested-dags = "examples.nested_dags:run_from_cli"
-argo-specific-extras = "examples.argo_specific_extras:run_from_cli"

--- a/tests/examples/argo/argo_specific_extras.yaml
+++ b/tests/examples/argo/argo_specific_extras.yaml
@@ -18,7 +18,7 @@ spec:
   - name: dag-long-task
     container:
       image: local.registry/dagger
-      command: [argo-specific-extras]
+      command: ["python", "examples/argo_specific_extras.py"]
       args: [
         --node-name, long-task
       ]

--- a/tests/examples/argo/hello_world.yaml
+++ b/tests/examples/argo/hello_world.yaml
@@ -17,7 +17,7 @@ spec:
   - name: dag-say-hello-world
     container:
       image: local.registry/dagger
-      command: [hello-world]
+      command: ["python", "examples/hello_world.py"]
       args: [
         --node-name, say-hello-world
       ]

--- a/tests/examples/argo/map_reduce.yaml
+++ b/tests/examples/argo/map_reduce.yaml
@@ -90,7 +90,7 @@ spec:
           key: "{{inputs.parameters.numbers_output_path}}"
     container:
       image: local.registry/dagger
-      command: [map-reduce]
+      command: ["python", "examples/map_reduce.py"]
       args: [
         --node-name, "generate-numbers",
         --input, parallel_steps, "{{inputs.artifacts.parallel_steps.path}}",
@@ -122,7 +122,7 @@ spec:
           key: "{{inputs.parameters.number_output_path}}"
     container:
       image: local.registry/dagger
-      command: [map-reduce]
+      command: ["python", "examples/map_reduce.py"]
       args: [
         --node-name, "multiply-by",
         --input, multiplier, "{{inputs.artifacts.multiplier.path}}",
@@ -153,7 +153,7 @@ spec:
           key: "{{inputs.parameters.sum_output_path}}"
     container:
       image: local.registry/dagger
-      command: [map-reduce]
+      command: ["python", "examples/map_reduce.py"]
       args: [
         --node-name, "sum-results",
         --input, numbers, "{{inputs.artifacts.numbers.path}}",

--- a/tests/examples/argo/nested_dags.yaml
+++ b/tests/examples/argo/nested_dags.yaml
@@ -120,8 +120,7 @@ spec:
       - --output
       - second_theme
       - '{{outputs.artifacts.second_theme.path}}'
-      command:
-      - nested-dags
+      command: ["python", "examples/nested_dags.py"]
       image: local.registry/dagger
       volumeMounts:
       - mountPath: /tmp/outputs/
@@ -199,8 +198,7 @@ spec:
       - --output
       - composition
       - '{{outputs.artifacts.composition.path}}'
-      command:
-      - nested-dags
+      command: ["python", "examples/nested_dags.py"]
       image: local.registry/dagger
       volumeMounts:
       - mountPath: /tmp/outputs/
@@ -234,8 +232,7 @@ spec:
       - --output
       - recording
       - '{{outputs.artifacts.recording.path}}'
-      command:
-      - nested-dags
+      command: ["python", "examples/nested_dags.py"]
       image: local.registry/dagger
       volumeMounts:
       - mountPath: /tmp/outputs/
@@ -313,8 +310,7 @@ spec:
       - --output
       - composition
       - '{{outputs.artifacts.composition.path}}'
-      command:
-      - nested-dags
+      command: ["python", "examples/nested_dags.py"]
       image: local.registry/dagger
       volumeMounts:
       - mountPath: /tmp/outputs/
@@ -348,8 +344,7 @@ spec:
       - --output
       - recording
       - '{{outputs.artifacts.recording.path}}'
-      command:
-      - nested-dags
+      command: ["python", "examples/nested_dags.py"]
       image: local.registry/dagger
       volumeMounts:
       - mountPath: /tmp/outputs/
@@ -393,8 +388,7 @@ spec:
       - --output
       - album
       - '{{outputs.artifacts.album.path}}'
-      command:
-      - nested-dags
+      command: ["python", "examples/nested_dags.py"]
       image: local.registry/dagger
       volumeMounts:
       - mountPath: /tmp/outputs/

--- a/tests/examples/argo/nested_map_reduce.yaml
+++ b/tests/examples/argo/nested_map_reduce.yaml
@@ -92,7 +92,7 @@ spec:
           key: "{{inputs.parameters.numbers_output_path}}"
     container:
       image: local.registry/dagger
-      command: [nested-map-reduce]
+      command: ["python", "examples/nested_map_reduce.py"]
       args: [
         --node-name, "fan-out",
         --input, parallel_steps, "{{inputs.artifacts.parallel_steps.path}}",
@@ -165,7 +165,7 @@ spec:
           key: "{{inputs.parameters.number_output_path}}"
     container:
       image: local.registry/dagger
-      command: [nested-map-reduce]
+      command: ["python", "examples/nested_map_reduce.py"]
       args: [
         --node-name, "map.map-1",
         --input, multiplier, "{{inputs.artifacts.multiplier.path}}",
@@ -197,7 +197,7 @@ spec:
           key: "{{inputs.parameters.number_output_path}}"
     container:
       image: local.registry/dagger
-      command: [nested-map-reduce]
+      command: ["python", "examples/nested_map_reduce.py"]
       args: [
         --node-name, "map.map-2",
         --input, multiplier, "{{inputs.artifacts.multiplier.path}}",
@@ -228,7 +228,7 @@ spec:
           key: "{{inputs.parameters.sum_output_path}}"
     container:
       image: local.registry/dagger
-      command: [nested-map-reduce]
+      command: ["python", "examples/nested_map_reduce.py"]
       args: [
         --node-name, reduce,
         --input, numbers, "{{inputs.artifacts.numbers.path}}",

--- a/tests/examples/argo/passing_parameters.yaml
+++ b/tests/examples/argo/passing_parameters.yaml
@@ -66,7 +66,7 @@ spec:
 
     container:
       image: local.registry/dagger
-      command: [passing-parameters]
+      command: ["python", "examples/passing_parameters.py"]
       args: [
         --node-name, double,
         --input, number, "{{inputs.artifacts.number.path}}",
@@ -96,7 +96,7 @@ spec:
           key: "{{inputs.parameters.squared-number_output_path}}"
     container:
       image: local.registry/dagger
-      command: [passing-parameters]
+      command: ["python", "examples/passing_parameters.py"]
       args: [
         --node-name, square,
         --input, number, "{{inputs.artifacts.number.path}}",


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please fill in the following template -->

#### What this PR does / why do we need it:

This PR fixes 2 bugs with our packaging process:

* It gives the right value to `dagger.__version__` (we were doing a string substitution with `sed` to align the Git tag with the library's version, but string interpolation didn't work properly, as we were using single quotes instead of double quotes).
* It removes the `scripts` section from Poetry, which we were using for local development and testing of the examples. The problem is, the intended behavior of the `scripts` section is to expose these scripts to the users of the library. So instead of doing this, we will be invoking the example scripts directly.

#### Release Notes

<!--
Write a release note to be included with the release of the next version
-->
```release-note
- Fixed `dagger.__version__`.
- Stopped exposing internal examples as Poetry scripts.
```

#### What type of changes to the API does this change introduce?

PATCH: No changes.


#### Checklist

- [x] I've read the [Contribution Guidelines](https://github.com/larribas/dagger/blob/main/CONTRIBUTING.md)
- [x] Updated the appropriate sections of the documentation.
- [x] I've added automated tests covering all success and error scenarios.
