### PR TITLE
feat: remove 'smart' double way of decorating tasks and DAGs in favor of a single way that plays better with IDEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ The following example shows how to run a simple hello world using the local runt
 from dagger.dsl import task, DAG, build
 from dagger.runtime.local import invoke
 
-@task
+@task()
 def say_hello_world():
     print("hello world!")
 
-@DAG
+@DAG()
 def hello_world_pipeline():
     say_hello_world()
 
@@ -70,24 +70,24 @@ The following example generates a list of numbers. The length of the list varies
 ```python
 import random
 
-@task
+@task()
 def generate_numbers():
     length = random.randint(3, 20)
     numbers = list(range(length))
     print(f"Generating the following list of numbers: {numbers}")
     return numbers
 
-@task
+@task()
 def raise_number(n, exponent):
     print(f"Raising {n} to a power of {exponent}")
     return n ** exponent
 
-@task
+@task()
 def sum_numbers(numbers):
     print(f"Calculating the sum of {numbers}")
     return sum(numbers)
 
-@DAG
+@DAG()
 def map_reduce_pipeline(exponent):
     return sum_numbers(
         [

--- a/codecov.yml
+++ b/codecov.yml
@@ -8,10 +8,9 @@ coverage:
   status:
    project:
     default:
-      threshold: 0.5%
-  patch:
-    default:
-      threshold: 0.1%
+      target: auto
+      threshold: 5%
+      base: auto 
 
 parsers:
   gcov:

--- a/dagger/dsl/build.py
+++ b/dagger/dsl/build.py
@@ -189,15 +189,15 @@ def _translate_invocation_ids_into_readable_names(
     For example, the following DAG definition:
 
     ```
-    @dsl.task
+    @dsl.task()
     def f():
         pass
 
-    @dsl.task
+    @dsl.task()
     def g():
         pass
 
-    @dsl.DAG
+    @dsl.DAG()
     def dag():
         f()
         g()

--- a/dagger/dsl/dsl.py
+++ b/dagger/dsl/dsl.py
@@ -8,35 +8,28 @@ from dagger.dsl.node_output_serializer import NodeOutputSerializer
 
 
 def DAG(
-    func: Callable = None,
     runtime_options: Mapping[str, Any] = None,
-):
+) -> Callable[[Callable], NodeInvocationRecorder]:
     """
     Decorate a function as a DAG.
 
     You can check examples of how to use the DSL in the examples/dsl directory.
     """
-    runtime_options = runtime_options or {}
 
-    if func:
+    def decorator(func: Callable) -> NodeInvocationRecorder:
         return NodeInvocationRecorder(
             func,
             node_type=NodeType.DAG,
             runtime_options=runtime_options,
         )
-    else:
-        return lambda func: NodeInvocationRecorder(
-            func,
-            node_type=NodeType.DAG,
-            runtime_options=runtime_options,
-        )
+
+    return decorator
 
 
 def task(
-    func: Callable = None,
     serializer: NodeOutputSerializer = NodeOutputSerializer(),
     runtime_options: Mapping[str, Any] = None,
-):
+) -> Callable[[Callable], NodeInvocationRecorder]:
     """
     Decorate a function as a Task.
 
@@ -44,17 +37,12 @@ def task(
     """
     runtime_options = runtime_options or {}
 
-    if func:
+    def decorator(func: Callable) -> NodeInvocationRecorder:
         return NodeInvocationRecorder(
             func,
             node_type=NodeType.TASK,
             serializer=serializer,
             runtime_options=runtime_options,
         )
-    else:
-        return lambda func: NodeInvocationRecorder(
-            func,
-            node_type=NodeType.TASK,
-            serializer=serializer,
-            runtime_options=runtime_options,
-        )
+
+    return decorator

--- a/dagger/dsl/node_invocation_recorder.py
+++ b/dagger/dsl/node_invocation_recorder.py
@@ -145,11 +145,11 @@ class NodeInvocationRecorder:
         For instance, given:
 
         ```
-        @dsl.task
+        @dsl.task()
         def f(a, b, c):
             pass
 
-        @dsl.DAG
+        @dsl.DAG()
         def dsl(a):
             f(a=a, b=2, c=3)
         ```

--- a/dagger/dsl/node_output_key_usage.py
+++ b/dagger/dsl/node_output_key_usage.py
@@ -14,7 +14,7 @@ class NodeOutputKeyUsage:
     has been used as such:
 
     ```
-    @dsl.DAG
+    @dsl.DAG()
     def dag():
         f_output = f()
         g(f_output["a"])

--- a/dagger/dsl/node_output_partition_usage.py
+++ b/dagger/dsl/node_output_partition_usage.py
@@ -14,15 +14,15 @@ class NodeOutputPartitionUsage:
     An instance of this class is returned whenever an output reference is iterated over.
 
     ```
-    @dsl.task
+    @dsl.task()
     def f() -> dict:
         return [1, 2, 3]
 
-    @dsl.task
+    @dsl.task()
     def g(n: int):
         print(n)
 
-    @dsl.DAG
+    @dsl.DAG()
     def dag():
         numbers = f()
         for n in numbers:

--- a/dagger/dsl/node_output_property_usage.py
+++ b/dagger/dsl/node_output_property_usage.py
@@ -14,7 +14,7 @@ class NodeOutputPropertyUsage:
     has been used as such:
 
     ```
-    @dsl.DAG
+    @dsl.DAG()
     def dag():
         f_output = f()
         g(f_output.a)

--- a/dagger/dsl/node_output_reference.py
+++ b/dagger/dsl/node_output_reference.py
@@ -13,15 +13,15 @@ class NodeOutputReference(Protocol):  # pragma: no cover
     It will be received as an argument by a task. For instance, when doing:
 
     ```
-    @dsl.task
+    @dsl.task()
     def f() -> int:
         return 2
 
-    @dsl.task
+    @dsl.task()
     def g(number: int):
         print(number)
 
-    @dsl.DAG
+    @dsl.DAG()
     def dag():
         f_output = f()
         g(f_output)

--- a/dagger/dsl/node_output_usage.py
+++ b/dagger/dsl/node_output_usage.py
@@ -17,11 +17,11 @@ class NodeOutputUsage:
     An instance of this class is returned whenever a task is invoked. For example:
 
     ```
-    @dsl.task
+    @dsl.task()
     def f() -> dict:
         return {"a": 1, "b": 2}
 
-    @dsl.DAG
+    @dsl.DAG()
     def dag():
         f_output = f()
     ```
@@ -31,7 +31,7 @@ class NodeOutputUsage:
     Instances can be passed as inputs to other tasks:
 
     ```
-    @dsl.DAG
+    @dsl.DAG()
     def dag():
         f_output = f()
         g(f_output)
@@ -40,7 +40,7 @@ class NodeOutputUsage:
     If the output is a mapping, you can access a specific key:
 
     ```
-    @dsl.DAG
+    @dsl.DAG()
     def dag():
         f_output = f()
         g(f_output["a"])
@@ -49,7 +49,7 @@ class NodeOutputUsage:
     If the output is an object, you can access a specific property:
 
     ```
-    @dsl.DAG
+    @dsl.DAG()
     def dag():
         f_output = f()
         g(f_output.a)
@@ -117,15 +117,15 @@ class NodeOutputUsage:
         output was used or not.
 
         ```
-        @dsl.task
+        @dsl.task()
         def f() -> int:
             return 2
 
-        @dsl.task
+        @dsl.task()
         def g(number: int):
             print(number)
 
-        @dsl.DAG
+        @dsl.DAG()
         def dag():
             f_output = f()
             g(f_output)

--- a/examples/composite_map_reduce.py
+++ b/examples/composite_map_reduce.py
@@ -7,25 +7,25 @@ This DAG shows how to compose map-reduce operations to model sophisticated pipel
 import dagger.dsl as dsl
 
 
-@dsl.task
+@dsl.task()
 def generate_numbers(partitions):
     """Return a list of numbers ranging from [1, partitions]."""
     return list(range(1, partitions + 1))
 
 
-@dsl.task
+@dsl.task()
 def map_number(n, exponent):
     """Elevate a number to an exponent."""
     return n ** exponent
 
 
-@dsl.task
+@dsl.task()
 def sum_numbers(numbers):
     """Sum a series of numbers supplied as an Iterable."""
     return sum(numbers)
 
 
-@dsl.DAG
+@dsl.DAG()
 def map_reduce(partitions, exponent):
     """Run a map-reduce operation on [1..partitions]. Mapping elevates each number to the supplied exponent. The reduction is the sum of all the elevated numbers."""
     return sum_numbers(
@@ -36,7 +36,7 @@ def map_reduce(partitions, exponent):
     )
 
 
-@dsl.DAG
+@dsl.DAG()
 def dag(partitions, exponent):
     """Run a map-reduce operation on [1..partitions]. Mapping calls a nested map-reduce operation with a varying number of partitions. The reduction is the sum of the result of each individual map-reduce operation."""
     return sum_numbers(

--- a/tests/dsl/test_black_box.py
+++ b/tests/dsl/test_black_box.py
@@ -20,11 +20,11 @@ from tests.dsl.verification import verify_dags_are_equivalent
 
 
 def test__build__hello_world():
-    @dsl.task
+    @dsl.task()
     def say_hello_world():
         print("hello world")
 
-    @dsl.DAG
+    @dsl.DAG()
     def dag():
         say_hello_world()
 
@@ -39,7 +39,7 @@ def test__build__hello_world():
 
 
 def test__build__dag_with_no_task_invocations():
-    @dsl.DAG
+    @dsl.DAG()
     def dag():
         pass
 
@@ -50,11 +50,11 @@ def test__build__dag_with_no_task_invocations():
 
 
 def test__build__multiple_calls_to_the_same_task():
-    @dsl.task
+    @dsl.task()
     def f():
         pass
 
-    @dsl.DAG
+    @dsl.DAG()
     def dag():
         f()
         f()
@@ -73,11 +73,11 @@ def test__build__multiple_calls_to_the_same_task():
 
 
 def test__build__input_from_param():
-    @dsl.task
+    @dsl.task()
     def say_hello(first_name):
         return f"hello {first_name}"
 
-    @dsl.DAG
+    @dsl.DAG()
     def dag(first_name):
         say_hello(first_name)
 
@@ -110,11 +110,11 @@ def test__build__input_from_literal_value():
         {"complex": ArbitraryObject()},
     ]
 
-    @dsl.task
+    @dsl.task()
     def inspect(hello, value):
         return f"{hello} {value} of type {type(value).__name__}"
 
-    @dsl.DAG
+    @dsl.DAG()
     def dag(hello):
         for value in literal_values:
             inspect(hello="hello...", value=value)
@@ -127,11 +127,11 @@ def test__build__input_from_literal_value():
 
 
 def test__build__input_from_param_with_different_names():
-    @dsl.task
+    @dsl.task()
     def say_hello(first_name):
         return f"hello {first_name}"
 
-    @dsl.DAG
+    @dsl.DAG()
     def dag(name):
         say_hello(name)
 
@@ -152,15 +152,15 @@ def test__build__input_from_param_with_different_names():
 
 
 def test__build__input_from_node_output():
-    @dsl.task
+    @dsl.task()
     def generate_random_number():
         return random.random()
 
-    @dsl.task
+    @dsl.task()
     def announce_number(n):
         print(f"the number was {n}!")
 
-    @dsl.DAG
+    @dsl.DAG()
     def dag():
         number = generate_random_number()
         announce_number(number)
@@ -185,15 +185,15 @@ def test__build__input_from_node_output():
 
 
 def test__build__using_sub_outputs():
-    @dsl.task
+    @dsl.task()
     def generate_complex_structure() -> dict:
         return {"a": 1, "b": 2}
 
-    @dsl.task
+    @dsl.task()
     def print_a_and_b(a, b):
         print(f"a={a}, b={b}")
 
-    @dsl.DAG
+    @dsl.DAG()
     def dag():
         d = generate_complex_structure()
         print_a_and_b(d["a"], d["b"])
@@ -222,11 +222,11 @@ def test__build__using_sub_outputs():
 
 
 def test__build__invalid_dag_return_value():
-    @dsl.task
+    @dsl.task()
     def echo(x):
         print(x)
 
-    @dsl.DAG
+    @dsl.DAG()
     def dag():
         echo(1)
         return "invalid"
@@ -241,11 +241,11 @@ def test__build__invalid_dag_return_value():
 
 
 def test__build__dag_outputs_from_return_value():
-    @dsl.task
+    @dsl.task()
     def generate_complex_structure() -> dict:
         return {"a": 1, "b": 2}
 
-    @dsl.DAG
+    @dsl.DAG()
     def dag():
         return generate_complex_structure()
 
@@ -268,11 +268,11 @@ def test__build__dag_outputs_from_return_value():
 
 
 def test__build__dag_outputs_from_sub_output():
-    @dsl.task
+    @dsl.task()
     def generate_complex_structure() -> dict:
         return {"a": 1, "b": 2}
 
-    @dsl.DAG
+    @dsl.DAG()
     def dag():
         return generate_complex_structure()["a"]
 
@@ -293,11 +293,11 @@ def test__build__dag_outputs_from_sub_output():
 
 
 def test__build__multiple_dag_outputs():
-    @dsl.task
+    @dsl.task()
     def generate_number() -> int:
         return 1
 
-    @dsl.DAG
+    @dsl.DAG()
     def dag():
         return {
             "a": generate_number(),
@@ -326,15 +326,15 @@ def test__build__multiple_dag_outputs():
 
 
 def test__build__nested_dags_simple():
-    @dsl.task
+    @dsl.task()
     def double(n: int) -> int:
         return n * 2
 
-    @dsl.DAG
+    @dsl.DAG()
     def inner_dag(n: int) -> int:
         return double(n)
 
-    @dsl.DAG
+    @dsl.DAG()
     def outer_dag(n: int):
         return inner_dag(n)
 
@@ -361,29 +361,29 @@ def test__build__nested_dags_simple():
 
 
 def test__build__nested_dags_complex():
-    @dsl.task
+    @dsl.task()
     def generate_seed() -> int:
         return 100
 
-    @dsl.task
+    @dsl.task()
     def generate_random_number(seed: int) -> int:
         random.seed(seed)
         return random.randint(0, 1000)
 
-    @dsl.task
+    @dsl.task()
     def multiply_number(number: int, multiplier: int) -> int:
         return number * multiplier
 
-    @dsl.task
+    @dsl.task()
     def print_number(number: int):
         print(f"I was told to print number {number}")
 
-    @dsl.DAG
+    @dsl.DAG()
     def inner_dag(seed: int, multiplier: int) -> int:
         number = generate_random_number(seed)
         return multiply_number(number, multiplier)
 
-    @dsl.DAG
+    @dsl.DAG()
     def outer_dag(multiplier: int):
         seed = generate_seed()
         multiplied_number = inner_dag(seed=seed, multiplier=multiplier)
@@ -449,7 +449,7 @@ def test__build__with_runtime_options():
     def inner_dag():
         say_hello_world()
 
-    @dsl.DAG
+    @dsl.DAG()
     def outer_dag():
         inner_dag()
 
@@ -483,18 +483,18 @@ def test__build__overriding_serializers():
             "pickle": 3,
         }
 
-    @dsl.task
+    @dsl.task()
     def announce_number(n: int):
         print(f"the number was {n}")
 
-    @dsl.DAG
+    @dsl.DAG()
     def announce_numbers(param: int, rand: int, json: int, pickle: int):
         announce_number(param)
         announce_number(rand)
         announce_number(json)
         announce_number(pickle)
 
-    @dsl.DAG
+    @dsl.DAG()
     def dag(param: int):
         rand = generate_single_number()
         mult = generate_multiple_numbers()
@@ -573,19 +573,19 @@ def test__build__overriding_serializers():
 
 
 def test__build__map_reduce():
-    @dsl.task
+    @dsl.task()
     def generate_numbers():
         return [1, 2, 3]
 
-    @dsl.task
+    @dsl.task()
     def map_number(n, exponent):
         return n ** exponent
 
-    @dsl.task
+    @dsl.task()
     def sum_numbers(numbers):
         return sum(numbers)
 
-    @dsl.DAG
+    @dsl.DAG()
     def dag(exponent):
         return sum_numbers(
             [
@@ -636,19 +636,19 @@ def test__build__map_reduce():
 
 
 def test__build__nested_map_reduce():
-    @dsl.task
+    @dsl.task()
     def generate_numbers(partitions):
         return list(range(partitions))
 
-    @dsl.task
+    @dsl.task()
     def map_number(n, exponent):
         return n ** exponent
 
-    @dsl.task
+    @dsl.task()
     def sum_numbers(numbers):
         return sum(numbers)
 
-    @dsl.DAG
+    @dsl.DAG()
     def map_reduce(partitions, exponent):
         return sum_numbers(
             [
@@ -657,7 +657,7 @@ def test__build__nested_map_reduce():
             ]
         )
 
-    @dsl.DAG
+    @dsl.DAG()
     def dag(partitions, exponent):
         return sum_numbers(
             [
@@ -743,15 +743,15 @@ def test__build__nested_map_reduce():
 
 
 def test__build__multiple_map_operations():
-    @dsl.task
+    @dsl.task()
     def generate_numbers():
         return [1, 2, 3]
 
-    @dsl.task
+    @dsl.task()
     def double(n):
         return n * 2
 
-    @dsl.DAG
+    @dsl.DAG()
     def dag():
         numbers = generate_numbers()
 
@@ -769,11 +769,11 @@ def test__build__multiple_map_operations():
 
 
 def test__build__nested_for_loops():
-    @dsl.task
+    @dsl.task()
     def generate_numbers(partitions):
         return list(range(partitions))
 
-    @dsl.DAG
+    @dsl.DAG()
     def dag(partitions):
         partitions = generate_numbers(partitions)
 

--- a/tests/dsl/test_dsl.py
+++ b/tests/dsl/test_dsl.py
@@ -5,35 +5,8 @@ from dagger.dsl.node_output_serializer import NodeOutputSerializer
 from dagger.serializer import AsPickle
 
 
-def test__task__as_wrapper():
-    def f():
-        pass
-
-    assert dsl.task(f) == NodeInvocationRecorder(
-        f,
-        node_type=NodeType.TASK,
-    )
-
-
-def test__task__as_wrapper_with_overrides():
-    serializer = NodeOutputSerializer(AsPickle())
-    runtime_options = {"my": "options"}
-
-    def f():
-        pass
-
-    assert dsl.task(
-        f, serializer=serializer, runtime_options=runtime_options
-    ) == NodeInvocationRecorder(
-        f,
-        node_type=NodeType.TASK,
-        serializer=serializer,
-        runtime_options=runtime_options,
-    )
-
-
 def test__task__as_decorator():
-    @dsl.task
+    @dsl.task()
     def f():
         pass
 
@@ -59,31 +32,8 @@ def test__task__as_decorator_with_overrides():
     )
 
 
-def test__dag__as_wrapper():
-    def g():
-        pass
-
-    assert dsl.DAG(g) == NodeInvocationRecorder(
-        g,
-        node_type=NodeType.DAG,
-    )
-
-
-def test__dag__as_wrapper_with_overrides():
-    runtime_options = {"my": "options"}
-
-    def g():
-        pass
-
-    assert dsl.DAG(g, runtime_options=runtime_options) == NodeInvocationRecorder(
-        g,
-        node_type=NodeType.DAG,
-        runtime_options=runtime_options,
-    )
-
-
 def test__dag__as_decorator():
-    @dsl.DAG
+    @dsl.DAG()
     def g():
         pass
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please fill in the following template -->

#### What this PR does / why do we need it:

We noticed that certain IDEs were complaining about the types returned by the `dsl.DAG` and `dsl.task` decorators.

At the moment, the same function can be used as a decorator, and as a function that returns a decorator.

This double behavior is achieved with some "smart" if condition that adds complexity to the code and the type system.

This PR simplifies the decorators and adds type hints to them. The result may be a bit more verbose, but it is simpler for both users and maintainers of the library.

#### Which issue(s) does this PR fix:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #28

#### Release Notes

<!--
Write a release note to be included with the release of the next version
-->
```release-note
Modified dsl decorators so that they are always parameterized (even if the list of parameters is empty).
```

#### What type of changes to the API does this change introduce?

MAJOR: This PR contains backwards-incompatible changes to the API (e.g. a new required argument was added to a public method)



#### Checklist

- [x] I've read the [Contribution Guidelines](https://github.com/larribas/dagger/blob/main/CONTRIBUTING.md)
- [x] Updated the appropriate sections of the documentation.
- [x] I've added automated tests covering all success and error scenarios.
