### PR TITLE
fix: tests failing on windows

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -124,7 +124,7 @@ jobs:
         os:
         - ubuntu-latest
         - macos-latest
-        # - windows-latest  Commented out until issue #17 is addressed
+        - windows-latest
         python: ["3.8", "3.9"]
     env:
       OS: ${{ matrix.os }}

--- a/tests/runtime/cli/test_cli.py
+++ b/tests/runtime/cli/test_cli.py
@@ -36,25 +36,29 @@ def test__invoke__whole_dag():
         outputs=dict(x_doubled_and_squared=FromNodeOutput("square", "x_squared")),
     )
 
-    with tempfile.NamedTemporaryFile() as x_input:
-        x_input.write(b"4")
-        x_input.seek(0)
+    with tempfile.TemporaryDirectory() as tmp:
+        x_input = os.path.join(tmp, "x_input")
+        x_output = os.path.join(tmp, "x_output")
 
-        with tempfile.NamedTemporaryFile() as x_doubled_and_squared_output:
-            invoke(
-                dag,
-                argv=itertools.chain(
-                    *[
-                        ["--input", "x", x_input.name],
-                        [
-                            "--output",
-                            "x_doubled_and_squared",
-                            x_doubled_and_squared_output.name,
-                        ],
-                    ]
-                ),
-            )
-            assert x_doubled_and_squared_output.read() == b"64"
+        with open(x_input, "wb") as f:
+            f.write(b"4")
+
+        invoke(
+            dag,
+            argv=itertools.chain(
+                *[
+                    ["--input", "x", x_input],
+                    [
+                        "--output",
+                        "x_doubled_and_squared",
+                        x_output,
+                    ],
+                ]
+            ),
+        )
+
+        with open(x_output, "rb") as f:
+            assert f.read() == b"64"
 
 
 def test__invoke__selecting_a_node_that_does_not_exist():
@@ -85,22 +89,26 @@ def test__invoke__selecting_a_node():
         outputs=dict(x_squared=FromNodeOutput("square", "x_squared")),
     )
 
-    with tempfile.NamedTemporaryFile() as x_input:
-        x_input.write(b"4")
-        x_input.seek(0)
+    with tempfile.TemporaryDirectory() as tmp:
+        x_input = os.path.join(tmp, "x_input")
+        x_output = os.path.join(tmp, "x_output")
 
-        with tempfile.NamedTemporaryFile() as x_squared_output:
-            invoke(
-                dag,
-                argv=itertools.chain(
-                    *[
-                        ["--node-name", "square"],
-                        ["--input", "x", x_input.name],
-                        ["--output", "x_squared", x_squared_output.name],
-                    ]
-                ),
-            )
-            assert x_squared_output.read() == b"16"
+        with open(x_input, "wb") as f:
+            f.write(b"4")
+
+        invoke(
+            dag,
+            argv=itertools.chain(
+                *[
+                    ["--node-name", "square"],
+                    ["--input", "x", x_input],
+                    ["--output", "x_squared", x_output],
+                ]
+            ),
+        )
+
+        with open(x_output, "rb") as f:
+            assert f.read() == b"16"
 
 
 def test__invoke__selecting_a_node_from_nested_dag():
@@ -126,22 +134,26 @@ def test__invoke__selecting_a_node_from_nested_dag():
         outputs=dict(x=FromNodeOutput("double", "x")),
     )
 
-    with tempfile.NamedTemporaryFile() as x_input:
-        x_input.write(b"4")
-        x_input.seek(0)
+    with tempfile.TemporaryDirectory() as tmp:
+        x_input = os.path.join(tmp, "x_input")
+        x_output = os.path.join(tmp, "x_output")
 
-        with tempfile.NamedTemporaryFile() as x_output:
-            invoke(
-                dag,
-                argv=itertools.chain(
-                    *[
-                        ["--node-name", "nested.square"],
-                        ["--input", "x", x_input.name],
-                        ["--output", "x", x_output.name],
-                    ]
-                ),
-            )
-            assert x_output.read() == b"16"
+        with open(x_input, "wb") as f:
+            f.write(b"4")
+
+        invoke(
+            dag,
+            argv=itertools.chain(
+                *[
+                    ["--node-name", "nested.square"],
+                    ["--input", "x", x_input],
+                    ["--output", "x", x_output],
+                ]
+            ),
+        )
+
+        with open(x_output, "rb") as f:
+            assert f.read() == b"16"
 
 
 def test__invoke__selecting_a_nested_node_that_does_not_exist():
@@ -177,22 +189,26 @@ def test__invoke__selecting_a_nested_dag():
         inputs=dict(x=FromParam()),
     )
 
-    with tempfile.NamedTemporaryFile() as x_input:
-        x_input.write(b"4")
-        x_input.seek(0)
+    with tempfile.TemporaryDirectory() as tmp:
+        x_input = os.path.join(tmp, "x_input")
+        x_output = os.path.join(tmp, "x_output")
 
-        with tempfile.NamedTemporaryFile() as x_output:
-            invoke(
-                dag,
-                argv=itertools.chain(
-                    *[
-                        ["--node-name", "nested"],
-                        ["--input", "x", x_input.name],
-                        ["--output", "x", x_output.name],
-                    ]
-                ),
-            )
-            assert x_output.read() == b"16"
+        with open(x_input, "wb") as f:
+            f.write(b"4")
+
+        invoke(
+            dag,
+            argv=itertools.chain(
+                *[
+                    ["--node-name", "nested"],
+                    ["--input", "x", x_input],
+                    ["--output", "x", x_output],
+                ]
+            ),
+        )
+
+        with open(x_output, "rb") as f:
+            assert f.read() == b"16"
 
 
 def test__invoke__nested_node_with_inputs_from_another_node_output():

--- a/tests/runtime/cli/test_locations.py
+++ b/tests/runtime/cli/test_locations.py
@@ -116,7 +116,10 @@ def test__store_output_in_location__with_partitioned_output():
 
 def test__store_output_in_location__when_file_already_exists_but_is_a_directory():
     with tempfile.TemporaryDirectory() as tmp:
-        with pytest.raises(IsADirectoryError):
+        # Although we generally expect an IsADirectoryError, Python captures
+        # a PermissionError on Windows due to a bug:
+        # https://bugs.python.org/issue43095
+        with pytest.raises((IsADirectoryError, PermissionError)):
             store_output_in_location(
                 output_location=tmp,
                 output_value=b"2",


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please fill in the following template -->

#### What this PR does / why do we need it:

This PR modifies the test suite so that it is compatible with Windows. There were 2 issues that made it incompatible:

- [`tempfile.NamedTemporaryFile`](https://docs.python.org/3/library/tempfile.html#tempfile.NamedTemporaryFile) cannot be read twice while open on Windows -> I switched to a regular file inside of a `tempfile.TemporaryDirectory`.
- On Windows, Python raises a `PermissionsError` whenever we try to read from or write to a path that is a directory. This is reported as a bug: https://bugs.python.org/issue43095


#### Which issue(s) does this PR fix:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #17 

#### Release Notes

<!--
Write a release note to be included with the release of the next version
-->
```release-note
Fixed test suite on Windows.
```

#### What type of changes to the API does this change introduce?

No user-facing changes. We just modified the test suite.


#### Checklist

- [x] I've read the [Contribution Guidelines](https://github.com/larribas/dagger/blob/main/CONTRIBUTING.md)
- [x] Updated the appropriate sections of the documentation.
- [x] I've added automated tests covering all success and error scenarios.
