### PR TITLE
fix: partition filenames are now sorted numerically instead of lexicographically to avoid issues like 2 > 10

### DIFF
--- a/dagger/runtime/cli/locations.py
+++ b/dagger/runtime/cli/locations.py
@@ -39,20 +39,19 @@ def retrieve_input_from_location(input_location: str) -> NodeOutput:
         If the current execution context doesn't have enough permissions to read the file.
     """
     if os.path.isdir(input_location):
-        partition_filenames = sorted(
-            [
-                fname
-                for fname in os.listdir(input_location)
-                if os.path.isfile(os.path.join(input_location, fname))
-                and fname != PARTITION_MANIFEST_FILENAME
-            ]
-        )
+        partition_filenames = [
+            fname
+            for fname in os.listdir(input_location)
+            if os.path.isfile(os.path.join(input_location, fname))
+            and fname != PARTITION_MANIFEST_FILENAME
+        ]
+        sorted_partition_filenames = sorted(partition_filenames, key=int)
 
         def load_lazily(partition_filename: str):
             with open(os.path.join(input_location, partition_filename), "rb") as f:
                 return f.read()
 
-        return PartitionedOutput(map(load_lazily, partition_filenames))
+        return PartitionedOutput(map(load_lazily, sorted_partition_filenames))
 
     else:
         with open(input_location, "rb") as f:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please fill in the following template -->

#### What this PR does / why do we need it:

This PR fixes a bug that happened on the CLI runtime whenever:

- We had a partitioned output.
- With the number of partitions n>=11.
- So that the CLI runtime stored each partition under the same directory, each with a filename numbered 0..n-1.
- And we had a fan-in/reduce task that expected to receive all the partitions as a list.
- And the order of those partitions was relevant.

The bug happened because we were sorting the filenames lexicographically, causing the string "2" to be greater than "10".

#### Release Notes

<!--
Write a release note to be included with the release of the next version
-->
```release-note
[CLI] Ensured partitions are always sorted in the same order
```

#### What type of changes to the API does this change introduce?

PATCH: No changes to the user-facing API.


#### Checklist

- [x] I've read the [Contribution Guidelines](https://github.com/larribas/dagger/blob/main/CONTRIBUTING.md)
- [x] Updated the appropriate sections of the documentation.
- [x] I've added automated tests covering all success and error scenarios.
