### PR TITLE
fix: bug when moving output files across file systems

### DIFF
--- a/dagger/runtime/cli/locations.py
+++ b/dagger/runtime/cli/locations.py
@@ -6,6 +6,7 @@ At the moment, only locations in the local filesystem are supported.
 
 import json
 import os
+import shutil
 from typing import Any
 
 from dagger.runtime.local import NodeOutput, PartitionedOutput
@@ -73,7 +74,7 @@ def store_output_in_location(
     """
     Store a serialized output into the specified location.
 
-    It uses os.rename(): https://docs.python.org/3/library/os.html#os.rename
+    It uses shutil.move(): https://docs.python.org/3/library/shutil.html#shutil.move
 
     Parameters
     ----------
@@ -110,7 +111,7 @@ def store_output_in_location(
 
         for i, src in enumerate(output_value):
             partition_filename = str(i)
-            os.rename(
+            shutil.move(
                 src.filename,
                 os.path.join(
                     output_location,
@@ -122,4 +123,4 @@ def store_output_in_location(
         with open(os.path.join(output_location, PARTITION_MANIFEST_FILENAME), "w") as p:
             json.dump(partition_filenames, p)
     else:
-        os.rename(output_value.filename, output_location)
+        shutil.move(output_value.filename, output_location)

--- a/tests/runtime/cli/test_cli.py
+++ b/tests/runtime/cli/test_cli.py
@@ -318,7 +318,9 @@ def test__invoke__with_invalid_output_location():
     )
     with pytest.raises(OSError) as e:
         with tempfile.TemporaryDirectory() as tmp:
-            invoke(dag, argv=["--output", "x", tmp])
+            nonexistent_dir = os.path.join(tmp, "nested-dir", "that-doesnt-exist")
+
+            invoke(dag, argv=["--output", "x", nonexistent_dir])
 
     assert str(e.value).startswith(
         "When storing output 'x', we got the following error:"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please fill in the following template -->

#### What this PR does / why do we need it:

This PR fixes issue #42, which prevented the CLI runtime from moving output files when the output directory provided was in a different file system (e.g. a different volume) than the temporary directory of the operating system.

The fix uses `shutil.move` instead of `os.rename`, as per the suggestion in this Stack Overflow discussion: https://stackoverflow.com/questions/42392600/oserror-errno-18-invalid-cross-device-link

#### Which issue(s) does this PR fix:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #42

#### Release Notes

<!--
Write a release note to be included with the release of the next version
-->
```release-note
Fixed a bug that prevented the CLI runtime from moving output files when the output directory was in a different file system.
```

#### What type of changes to the API does this change introduce?

PATCH: A bug was fixed without any change to the user-facing API.


#### Checklist

- [x] I've read the [Contribution Guidelines](https://github.com/larribas/dagger/blob/main/CONTRIBUTING.md)
- [x] Updated the appropriate sections of the documentation.
- [x] I've added automated tests covering all success and error scenarios.
