### PR TITLE
Allow continues on

### DIFF
--- a/dagger/runtime/argo/workflow_spec.py
+++ b/dagger/runtime/argo/workflow_spec.py
@@ -316,6 +316,12 @@ def _dag_task(
             input_type=node.inputs[node.partition_by_input],
         )
 
+    dag_task = with_extra_spec_options(
+        original=dag_task,
+        extra_options=node.runtime_options.get("argo_task_overrides", {}),
+        context=".".join(node_address) if node_address else "DAG",
+    )
+
     return dag_task
 
 

--- a/docs/code_snippets/argo_runtime/extra_task_options.py
+++ b/docs/code_snippets/argo_runtime/extra_task_options.py
@@ -1,0 +1,15 @@
+from dagger import dsl
+
+
+@dsl.task(
+    runtime_options={
+        "argo_task_overrides": {
+            # Available options to override: https://argoproj.github.io/argo-workflows/fields/#dagtask
+            "continueOn": {
+                "failed": True,
+            },
+        },
+    }
+)
+def say_hello():
+    print("Hello!")

--- a/docs/user-guide/runtimes/argo.md
+++ b/docs/user-guide/runtimes/argo.md
@@ -106,7 +106,13 @@ Nevertheless, ___Dagger_ allows you to set all of these settings together with t
     --8<-- "docs/code_snippets/argo_runtime/extra_container_options.py"
     ```
 
-=== "Template options"
+=== "Task options"
+
+    ```python
+    --8<-- "docs/code_snippets/argo_runtime/extra_task_options.py"
+    ```
+
+=== "Task Template options"
 
     ```python
     --8<-- "docs/code_snippets/argo_runtime/extra_template_options.py"

--- a/examples/argo_map_reduce_continue_on.py
+++ b/examples/argo_map_reduce_continue_on.py
@@ -1,0 +1,46 @@
+"""
+# Map-Reduce continues on failure in Argo.
+
+This DAG executes a map-reduce operation where some of the "mapping" operations fail, but the DAG runs to completion and is able to run the "reduce" step only with the successful results.
+"""
+
+from dagger import dsl
+
+
+@dsl.task()
+def generate_partitions():  # noqa
+    return [1, 2, 3, 4]
+
+
+@dsl.task(
+    runtime_options={
+        "argo_task_overrides": {
+            "continueOn": {
+                "failed": True,
+            },
+        },
+    }
+)
+def succeed_if_even(num):  # noqa
+    if (num % 2) == 0:
+        return num
+    else:
+        raise ValueError("This is odd!")
+
+
+@dsl.task()
+def gather_all_even_numbers(numbers):  # noqa
+    print(f"Even numbers were: {numbers}")
+
+
+@dsl.DAG()
+def dag():  # noqa
+    even_numbers = [succeed_if_even(num) for num in generate_partitions()]
+    gather_all_even_numbers(even_numbers)
+
+
+if __name__ == "__main__":
+    """Define a command-line interface for this DAG, using the CLI runtime. Check the documentation to understand why this is relevant or necessary."""
+    from dagger.runtime.cli import invoke
+
+    invoke(dsl.build(dag))

--- a/tests/docs/test_argo_runtime.py
+++ b/tests/docs/test_argo_runtime.py
@@ -38,6 +38,12 @@ def test_extra_template_options():
     assert say_hello.runtime_options["argo_template_overrides"] != {}
 
 
+def test_extra_task_options():
+    from docs.code_snippets.argo_runtime.extra_task_options import say_hello
+
+    assert say_hello.runtime_options["argo_task_overrides"] != {}
+
+
 def test_extra_dag_template_options():
     from docs.code_snippets.argo_runtime.extra_dag_template_options import dag
 

--- a/tests/examples/argo/argo_map_reduce_continue_on.yaml
+++ b/tests/examples/argo/argo_map_reduce_continue_on.yaml
@@ -1,0 +1,128 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: continue-on-fail-
+spec:
+  entrypoint: dag
+  templates:
+  - dag:
+      tasks:
+      - arguments:
+          parameters:
+          - name: return_value_output_path
+            value: '{{workflow.uid}}/{{inputs.parameters.name}}/generate-partitions/return_value.json'
+        name: generate-partitions
+        template: dag-generate-partitions
+      - arguments:
+          artifacts:
+          - name: num
+            s3:
+              key: '{{workflow.uid}}/{{inputs.parameters.name}}/generate-partitions/return_value.json/{{item}}'
+          parameters:
+          - name: return_value_output_path
+            value: '{{workflow.uid}}/{{inputs.parameters.name}}/succeed-if-even/return_value.json/{{item}}'
+        continueOn:
+          failed: true
+        dependencies:
+        - generate-partitions
+        name: succeed-if-even
+        template: dag-succeed-if-even
+        withParam: '{{tasks.generate-partitions.outputs.parameters.return_value_partitions}}'
+      - arguments:
+          artifacts:
+          - name: numbers
+            s3:
+              key: '{{workflow.uid}}/{{inputs.parameters.name}}/succeed-if-even/return_value.json'
+        dependencies:
+        - succeed-if-even
+        name: gather-all-even-numbers
+        template: dag-gather-all-even-numbers
+    inputs:
+      parameters:
+      - name: name
+        value: dag
+    name: dag
+  - container:
+      args:
+      - --node-name
+      - generate-partitions
+      - --output
+      - return_value
+      - '{{outputs.artifacts.return_value.path}}'
+      command:
+      - python
+      - examples/argo_map_reduce_continue_on.py
+      image: local.registry/dagger
+      volumeMounts:
+      - mountPath: /tmp/outputs
+        name: outputs
+    inputs:
+      parameters:
+      - name: return_value_output_path
+    name: dag-generate-partitions
+    outputs:
+      artifacts:
+      - archive:
+          none: {}
+        name: return_value
+        path: /tmp/outputs/return_value.json
+        s3:
+          key: '{{inputs.parameters.return_value_output_path}}'
+      parameters:
+      - name: return_value_partitions
+        valueFrom:
+          path: '{{outputs.artifacts.return_value.path}}/partitions.json'
+    volumes:
+    - emptyDir: {}
+      name: outputs
+  - container:
+      args:
+      - --node-name
+      - succeed-if-even
+      - --input
+      - num
+      - '{{inputs.artifacts.num.path}}'
+      - --output
+      - return_value
+      - '{{outputs.artifacts.return_value.path}}'
+      command:
+      - python
+      - examples/argo_map_reduce_continue_on.py
+      image: local.registry/dagger
+      volumeMounts:
+      - mountPath: /tmp/outputs
+        name: outputs
+    inputs:
+      artifacts:
+      - name: num
+        path: /tmp/inputs/num.json
+      parameters:
+      - name: return_value_output_path
+    name: dag-succeed-if-even
+    outputs:
+      artifacts:
+      - archive:
+          none: {}
+        name: return_value
+        path: /tmp/outputs/return_value.json
+        s3:
+          key: '{{inputs.parameters.return_value_output_path}}'
+    volumes:
+    - emptyDir: {}
+      name: outputs
+  - container:
+      args:
+      - --node-name
+      - gather-all-even-numbers
+      - --input
+      - numbers
+      - '{{inputs.artifacts.numbers.path}}'
+      command:
+      - python
+      - examples/argo_map_reduce_continue_on.py
+      image: local.registry/dagger
+    inputs:
+      artifacts:
+      - name: numbers
+        path: /tmp/inputs/numbers.json
+    name: dag-gather-all-even-numbers


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please fill in the following template -->

#### What this PR does / why do we need it:

This PR extends the Task runtime options the Argo runtime understands to allow users to set extra options for the [DAGTask spec](https://argoproj.github.io/argo-workflows/fields/#dagtask).

The most important key we're looking forward to override is the `continueOn` attribute, which will allow map-reduce operations to work even if some of the "mapping" operations failed.

#### Release Notes

<!--
Write a release note to be included with the release of the next version
-->
```release-note
[Argo] Extended the runtime options Argo understands to allow setting DAGTask keys (such as continueOn)
```

#### What type of changes to the API does this change introduce?

MINOR: The API of the Argo runtime was extended.


#### Checklist

- [x] I've read the [Contribution Guidelines](https://github.com/larribas/dagger/blob/main/CONTRIBUTING.md)
- [x] Updated the appropriate sections of the documentation.
- [x] I've added automated tests covering all success and error scenarios.
