### PR TITLE
feat(dsl): accept variadic **kwargs

### DIFF
--- a/dagger/dsl/node_invocation_recorder.py
+++ b/dagger/dsl/node_invocation_recorder.py
@@ -17,6 +17,11 @@ from dagger.dsl.node_output_reference import NodeOutputReference
 from dagger.dsl.node_output_serializer import NodeOutputSerializer
 from dagger.dsl.node_output_usage import NodeOutputUsage
 
+INVALID_PARAM_TYPES = [
+    inspect.Parameter.POSITIONAL_ONLY,
+    inspect.Parameter.VAR_POSITIONAL,
+]
+
 
 class NodeInvocationRecorder:
     """
@@ -33,6 +38,8 @@ class NodeInvocationRecorder:
         runtime_options: Mapping[str, Any] = None,
         override_id: Optional[str] = None,
     ):
+        _validate_func(func)
+
         self._func = func
         self._node_type = node_type
         self._serializer = serializer
@@ -98,19 +105,22 @@ class NodeInvocationRecorder:
 
         try:
             bound_args = sig.bind(*args, **kwargs)
+            arguments = {**bound_args.arguments}
         except TypeError as e:
             raise TypeError(
                 f"You have invoked the task '{self._func.__name__}' with the following arguments: args={args} kwargs={kwargs}. However, the signature of the function is '{sig}'. The following error was raised as a result of this mismatch: {e}"
             ) from e
 
-        if "kwargs" in bound_args.arguments:
-            arguments = {
-                **bound_args.arguments,
-                **bound_args.arguments.get("kwargs", {}),
-            }
-            del arguments["kwargs"]
-        else:
-            arguments = bound_args.arguments
+        # If there are arguments which have been bound to variadic keyword parameters,
+        # pass them at the same level as the other parameters.
+        kwarg_parameters = [
+            name
+            for name, param in sig.parameters.items()
+            if param.kind == inspect.Parameter.VAR_KEYWORD
+        ]
+        for kwarg_param_name in kwarg_parameters:
+            arguments = {**arguments, **arguments[kwarg_param_name]}
+            del arguments[kwarg_param_name]
 
         return {k: self._sanitize_argument(k, v) for k, v in arguments.items()}
 
@@ -214,4 +224,15 @@ class NodeInvocationRecorder:
             and self._overridden_id == obj._overridden_id
             and self._serializer == obj._serializer
             and self._runtime_options == obj._runtime_options
+        )
+
+
+def _validate_func(func: Callable):
+    sig = inspect.signature(func)
+    params_with_invalid_types = [
+        p for p in sig.parameters.values() if p.kind in INVALID_PARAM_TYPES
+    ]
+    if params_with_invalid_types:
+        raise ValueError(
+            f"You have decorated a function with the signature '{str(sig)}'. However, the DSL only accepts parameters that can be injected via keyword arguments. Therefore, the parameters '{params_with_invalid_types}' are invalid."
         )

--- a/dagger/dsl/node_invocation_recorder.py
+++ b/dagger/dsl/node_invocation_recorder.py
@@ -103,9 +103,16 @@ class NodeInvocationRecorder:
                 f"You have invoked the task '{self._func.__name__}' with the following arguments: args={args} kwargs={kwargs}. However, the signature of the function is '{sig}'. The following error was raised as a result of this mismatch: {e}"
             ) from e
 
-        return {
-            k: self._sanitize_argument(k, v) for k, v in bound_args.arguments.items()
-        }
+        if "kwargs" in bound_args.arguments:
+            arguments = {
+                **bound_args.arguments,
+                **bound_args.arguments.get("kwargs", {}),
+            }
+            del arguments["kwargs"]
+        else:
+            arguments = bound_args.arguments
+
+        return {k: self._sanitize_argument(k, v) for k, v in arguments.items()}
 
     def _sanitize_argument(self, name: str, arg: Any) -> Any:
         # Case 1: Fan-in of multiple outputs from a partitioned node

--- a/tests/dsl/test_black_box.py
+++ b/tests/dsl/test_black_box.py
@@ -225,10 +225,10 @@ def test__build__input_from_node_output():
     )
 
 
-def test__build__function_with_variadic_parameters():
+def test__build__function_with_variadic_keyword_parameters():
     @dsl.task()
-    def variadic_kwargs_as_dict(**kwargs):
-        return kwargs
+    def variadic_kwargs_as_dict(**keyword_arguments):
+        return keyword_arguments
 
     @dsl.DAG()
     def dag(v1, v2):

--- a/tests/dsl/test_black_box.py
+++ b/tests/dsl/test_black_box.py
@@ -225,6 +225,43 @@ def test__build__input_from_node_output():
     )
 
 
+def test__build__function_with_variadic_parameters():
+    @dsl.task()
+    def variadic_kwargs_as_dict(**kwargs):
+        return kwargs
+
+    @dsl.DAG()
+    def dag(v1, v2):
+        return variadic_kwargs_as_dict(a=v1, b=v2)
+
+    verify_dags_are_equivalent(
+        dsl.build(dag),
+        DAG(
+            inputs={
+                "v1": FromParam("v1"),
+                "v2": FromParam("v2"),
+            },
+            outputs={
+                "return_value": FromNodeOutput(
+                    "variadic-kwargs-as-dict", "return_value"
+                ),
+            },
+            nodes={
+                "variadic-kwargs-as-dict": Task(
+                    variadic_kwargs_as_dict.func,
+                    inputs={
+                        "a": FromParam("v1"),
+                        "b": FromParam("v2"),
+                    },
+                    outputs={
+                        "return_value": FromReturnValue(),
+                    },
+                ),
+            },
+        ),
+    )
+
+
 def test__build__using_sub_outputs():
     @dsl.task()
     def generate_complex_structure() -> dict:

--- a/tests/dsl/test_node_invocation_recorder.py
+++ b/tests/dsl/test_node_invocation_recorder.py
@@ -184,6 +184,22 @@ def test__task_invocation__with_a_partitioned_input():
     }
 
 
+def test__task_invocation__function_with_variadic_positional_parameters():
+    def with_positional_args(x, y, /, z, *args):
+        pass
+
+    with pytest.raises(ValueError) as e:
+        NodeInvocationRecorder(
+            func=with_positional_args,
+            node_type=NodeType.TASK,
+        )
+
+    assert (
+        str(e.value)
+        == 'You have decorated a function with the signature \'(x, y, /, z, *args)\'. However, the DSL only accepts parameters that can be injected via keyword arguments. Therefore, the parameters \'[<Parameter "x">, <Parameter "y">, <Parameter "*args">]\' are invalid.'
+    )
+
+
 def test__representation():
     def my_func(x, y):
         return x + y


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please fill in the following template -->

#### What this PR does / why do we need it:

This PR adds support for variadic keyword arguments (`**kwargs`) on functions defined using the imperative DSL.

#### Release Notes

<!--
Write a release note to be included with the release of the next version
-->
```release-note
[DSL] Added support for functions receiving **kwargs
```

#### What type of changes to the API does this change introduce?

MINOR: The API of the imperative DSL has been extended to support functions with `**kwargs` in their signature.


#### Checklist

- [x] I've read the [Contribution Guidelines](https://github.com/larribas/dagger/blob/main/CONTRIBUTING.md)
- [x] Updated the appropriate sections of the documentation.
- [x] I've added automated tests covering all success and error scenarios.
