### PR TITLE
fix(dsl): mismatched output names when using subkeys of a nested dag

### DIFF
--- a/dagger/dsl/build.py
+++ b/dagger/dsl/build.py
@@ -154,7 +154,7 @@ def _build_dag_outputs(
     if isinstance(dag_output, NodeOutputReference):
         outputs_by_name = {"return_value": dag_output}
     elif isinstance(dag_output, Mapping):
-        outputs_by_name = dag_output
+        outputs_by_name = {f"key_{key}": value for key, value in dag_output.items()}
     elif dag_output is not None:
         raise TypeError(
             f"This DAG returned a value of type {type(dag_output).__name__}. Functions decorated with `dsl.DAG` may only return two types of values: The output of another node or a mapping of [str, the output of another node]"

--- a/tests/dsl/test_build.py
+++ b/tests/dsl/test_build.py
@@ -257,12 +257,12 @@ def test__build_dag_outputs__when_multiple_outputs_are_returned():
             "id-2": "name-2",
         },
     ) == {
-        "x": FromNodeOutput(
+        "key_x": FromNodeOutput(
             "name-1",
             "output",
             serializer=AsPickle(),
         ),
-        "y": FromNodeOutput(
+        "key_y": FromNodeOutput(
             "name-2",
             "return_value",
             serializer=AsJSON(indent=1),


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please fill in the following template -->

#### What this PR does / why do we need it:

This PR fixes the bug identified in #47, wherein building a DAG that depended on sub-keys of another DAG (that returned multiple outputs) exhibited a mismatch between the name of the output we were accessing and the output the inner DAG actually generated.

#### Which issue(s) does this PR fix:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #47

#### Release Notes

<!--
Write a release note to be included with the release of the next version
-->
```release-note
[DSL] Fixed a bug that prevented us from building DAGs that depended on nested DAGs with multiple outputs.
```

#### What type of changes to the API does this change introduce?

PATCH: A bug was fixed without any impact to the user-facing API.


#### Checklist

- [x] I've read the [Contribution Guidelines](https://github.com/larribas/dagger/blob/main/CONTRIBUTING.md)
- [x] Updated the appropriate sections of the documentation.
- [x] I've added automated tests covering all success and error scenarios.
