### PR TITLE
feat: initial commit support default values

### DIFF
--- a/dagger/dag/__init__.py
+++ b/dagger/dag/__init__.py
@@ -1,10 +1,4 @@
 """Define workflows/pipelines as Directed Acyclic Graphs (DAGs) of Tasks."""
 
-from dagger.dag.dag import (  # noqa
-    DAG,
-    Node,
-    SupportedInputs,
-    SupportedOutputs,
-    validate_parameters,
-)
+from dagger.dag.dag import DAG, Node, SupportedInputs, SupportedOutputs  # noqa
 from dagger.dag.topological_sort import CyclicDependencyError  # noqa

--- a/dagger/dag/dag.py
+++ b/dagger/dag/dag.py
@@ -276,6 +276,9 @@ def _validate_input_from_param(
     input_type: FromParam,
     dag_inputs: Mapping[str, SupportedInputs],
 ):
+    if input_type.has_default_value():
+        return
+
     # If the param name has not been overridden, we assume it has the same name as the input
     name = input_type.name or input_name
 

--- a/dagger/dag/dag.py
+++ b/dagger/dag/dag.py
@@ -1,6 +1,5 @@
 """Define the data structure for a DAG and validate all its components upon initialization."""
 import re
-import warnings
 from typing import Any, List, Mapping, Optional, Set, Union
 from typing import get_args as get_type_args
 
@@ -8,7 +7,6 @@ from dagger.dag.topological_sort import topological_sort
 from dagger.data_structures import FrozenMapping
 from dagger.input import FromNodeOutput, FromParam
 from dagger.input import validate_name as validate_input_name
-from dagger.input.empty_default_value import EmptyDefaultValue
 from dagger.output import validate_name as validate_output_name
 from dagger.task import SupportedInputs as SupportedTaskInputs
 from dagger.task import Task
@@ -182,46 +180,6 @@ class DAG:
             and self._inputs == obj._inputs
             and self._outputs == obj._outputs
             and self._runtime_options == obj._runtime_options
-        )
-
-
-def validate_parameters(
-    inputs: Mapping[str, SupportedInputs],
-    params: Mapping[str, Any],
-):
-    """
-    Validate a series of parameters against the inputs of a DAG.
-
-    Parameters
-    ----------
-    inputs
-        A mapping of input names to inputs.
-
-    params
-        A mapping of input names to parameters or input values.
-        Input values must be passed in their serialized representation.
-
-    Raises
-    ------
-    ValueError
-        If the set of parameters does not contain all the required inputs.
-    """
-    required_inputs = {
-        name
-        for name, input_ in inputs.items()
-        if not isinstance(input_, FromParam)
-        or input_.default_value == EmptyDefaultValue()
-    }
-    missing_params = required_inputs - params.keys()
-    if missing_params:
-        raise ValueError(
-            f"The parameters supplied to this node were supposed to contain the following parameters: {sorted(list(required_inputs))}. However, only the following parameters were actually supplied: {sorted(list(params))}. We are missing: {sorted(list(missing_params))}."
-        )
-
-    superfluous_params = params.keys() - inputs.keys()
-    if superfluous_params:
-        warnings.warn(
-            f"The following parameters were supplied to this node, but are not necessary: {sorted(list(superfluous_params))}"
         )
 
 

--- a/dagger/dag/dag.py
+++ b/dagger/dag/dag.py
@@ -276,6 +276,9 @@ def _validate_input_from_param(
     input_type: FromParam,
     dag_inputs: Mapping[str, SupportedInputs],
 ):
+    # If the node's input has a default value and the parent doesn't declare a matching input,
+    # we can simply use the default value. Therefore, it wouldn't constitute a validation error.
+    # We take advantage of this behavior when building DAGs with hardcoded and default values.
     if input_type.has_default_value():
         return
 

--- a/dagger/dag/dag.py
+++ b/dagger/dag/dag.py
@@ -215,13 +215,13 @@ def validate_parameters(
     missing_params = required_inputs - params.keys()
     if missing_params:
         raise ValueError(
-            f"The parameters supplied to this DAG were supposed to contain the following parameters: {sorted(list(required_inputs))}. However, only the following parameters were actually supplied: {sorted(list(params))}. We are missing: {sorted(list(missing_params))}."
+            f"The parameters supplied to this node were supposed to contain the following parameters: {sorted(list(required_inputs))}. However, only the following parameters were actually supplied: {sorted(list(params))}. We are missing: {sorted(list(missing_params))}."
         )
 
     superfluous_params = params.keys() - required_inputs
     if superfluous_params:
         warnings.warn(
-            f"The following parameters were supplied to this DAG, but are not necessary: {sorted(list(superfluous_params))}"
+            f"The following parameters were supplied to this node, but are not necessary: {sorted(list(superfluous_params))}"
         )
 
 

--- a/dagger/dag/dag.py
+++ b/dagger/dag/dag.py
@@ -218,7 +218,7 @@ def validate_parameters(
             f"The parameters supplied to this node were supposed to contain the following parameters: {sorted(list(required_inputs))}. However, only the following parameters were actually supplied: {sorted(list(params))}. We are missing: {sorted(list(missing_params))}."
         )
 
-    superfluous_params = params.keys() - required_inputs
+    superfluous_params = params.keys() - inputs.keys()
     if superfluous_params:
         warnings.warn(
             f"The following parameters were supplied to this node, but are not necessary: {sorted(list(superfluous_params))}"

--- a/dagger/dsl/build.py
+++ b/dagger/dsl/build.py
@@ -15,8 +15,9 @@ from dagger.dsl.node_output_partition_usage import NodeOutputPartitionUsage
 from dagger.dsl.node_output_property_usage import NodeOutputPropertyUsage
 from dagger.dsl.node_output_reference import NodeOutputReference
 from dagger.dsl.node_output_usage import NodeOutputUsage
-from dagger.dsl.parameter_usage import EmptyDefaultValue, ParameterUsage
+from dagger.dsl.parameter_usage import ParameterUsage
 from dagger.input import FromNodeOutput, FromParam
+from dagger.input.empty_default_value import EmptyDefaultValue
 from dagger.output import FromKey, FromProperty, FromReturnValue
 from dagger.serializer import DefaultSerializer
 from dagger.task import SupportedOutputs as SupportedTaskOutputs

--- a/dagger/dsl/build.py
+++ b/dagger/dsl/build.py
@@ -16,8 +16,7 @@ from dagger.dsl.node_output_property_usage import NodeOutputPropertyUsage
 from dagger.dsl.node_output_reference import NodeOutputReference
 from dagger.dsl.node_output_usage import NodeOutputUsage
 from dagger.dsl.parameter_usage import ParameterUsage
-from dagger.input import FromNodeOutput, FromParam
-from dagger.input.empty_default_value import EmptyDefaultValue
+from dagger.input import EmptyDefaultValue, FromNodeOutput, FromParam
 from dagger.output import FromKey, FromProperty, FromReturnValue
 from dagger.serializer import DefaultSerializer
 from dagger.task import SupportedOutputs as SupportedTaskOutputs

--- a/dagger/dsl/build.py
+++ b/dagger/dsl/build.py
@@ -15,7 +15,7 @@ from dagger.dsl.node_output_partition_usage import NodeOutputPartitionUsage
 from dagger.dsl.node_output_property_usage import NodeOutputPropertyUsage
 from dagger.dsl.node_output_reference import NodeOutputReference
 from dagger.dsl.node_output_usage import NodeOutputUsage
-from dagger.dsl.parameter_usage import ParameterUsage, EmptyDefaultValue
+from dagger.dsl.parameter_usage import EmptyDefaultValue, ParameterUsage
 from dagger.input import FromNodeOutput, FromParam
 from dagger.output import FromKey, FromProperty, FromReturnValue
 from dagger.serializer import DefaultSerializer

--- a/dagger/dsl/build.py
+++ b/dagger/dsl/build.py
@@ -259,7 +259,6 @@ def _build_node_input(
         return FromNodeOutput(
             node=node_names_by_id[input_type.invocation_id],
             output=input_type.output_name,
-            default_value=input_type.default_value,
             serializer=input_type.serializer,
         )
 

--- a/dagger/dsl/dag_parent.py
+++ b/dagger/dsl/dag_parent.py
@@ -1,0 +1,39 @@
+"""Relevant information about the parent of a DAG."""
+
+from typing import Mapping
+
+from dagger.dsl.node_invocations import NodeInputReference
+
+
+class DAGParent:
+    """Contains information about a DAG's parent to allow us to build the child DAG."""
+
+    def __init__(
+        self,
+        inputs: Mapping[str, NodeInputReference],
+        node_names_by_id: Mapping[str, str],
+    ):
+        self._inputs = inputs
+        self._node_names_by_id = node_names_by_id
+
+    @property
+    def inputs(self) -> Mapping[str, NodeInputReference]:
+        """Return the name of the key this reference points to."""
+        return self._inputs
+
+    @property
+    def node_names_by_id(self) -> Mapping[str, str]:
+        """Return a mapping of node IDs to unique node names."""
+        return self._node_names_by_id
+
+    def __repr__(self) -> str:
+        """Get a human-readable string representation of this object."""
+        return f"DAGParent(inputs={self._inputs}, node_names_by_id={self._node_names_by_id})"
+
+    def __eq__(self, obj) -> bool:
+        """Return true if both objects are equivalent."""
+        return (
+            isinstance(obj, DAGParent)
+            and self._inputs == obj._inputs
+            and self._node_names_by_id == obj._node_names_by_id
+        )

--- a/dagger/dsl/node_invocation_recorder.py
+++ b/dagger/dsl/node_invocation_recorder.py
@@ -157,7 +157,8 @@ class NodeInvocationRecorder:
                 arg.consume()
 
     def _func_with_preset_params(self, arguments: Mapping[str, Any]) -> Callable:
-        """
+        """Return function with all arguments preset.
+
         Return the function where all the arguments that come from a literal value
         (instead of a reference built by the DSL) are preset and don't need to be
         injected as a parameter anymore.

--- a/dagger/dsl/node_invocation_recorder.py
+++ b/dagger/dsl/node_invocation_recorder.py
@@ -108,7 +108,10 @@ class NodeInvocationRecorder:
             arguments = {**bound_args.arguments}
         except TypeError as e:
             raise TypeError(
-                f"You have invoked the task '{self._func.__name__}' with the following arguments: args={args} kwargs={kwargs}. However, the signature of the function is '{sig}'. The following error was raised as a result of this mismatch: {e}"
+                f"You have invoked the task '{self._func.__name__}' with the following "
+                f"arguments: args={args} kwargs={kwargs}. However, the signature of the"
+                f" function is '{sig}'. The following error was raised as a result of "
+                f"this mismatch: {e}"
             ) from e
 
         # If there are arguments which have been bound to variadic keyword parameters,
@@ -182,6 +185,7 @@ class NodeInvocationRecorder:
                 preset_params[argument_name] = argument_value
 
         if preset_params:
+            # TODO @lorenzo can we review this? no test coverage and maybe has a bug
             return lambda *args, **kwargs: self._func(
                 *args, **{**kwargs, **preset_params}
             )

--- a/dagger/dsl/node_invocation_recorder.py
+++ b/dagger/dsl/node_invocation_recorder.py
@@ -74,7 +74,6 @@ class NodeInvocationRecorder:
         )
 
         invocations = node_invocations.get([])
-        # TODO do not pass default value of param to nodes where it's used
         invocations.append(
             NodeInvocation(
                 id=invocation_id,

--- a/dagger/dsl/node_invocation_recorder.py
+++ b/dagger/dsl/node_invocation_recorder.py
@@ -74,6 +74,7 @@ class NodeInvocationRecorder:
         )
 
         invocations = node_invocations.get([])
+        # TODO do not pass default value of param to nodes where it's used
         invocations.append(
             NodeInvocation(
                 id=invocation_id,
@@ -157,7 +158,9 @@ class NodeInvocationRecorder:
 
     def _func_with_preset_params(self, arguments: Mapping[str, Any]) -> Callable:
         """
-        Return the function where all the arguments that come from a literal value (instead of a reference built by the DSL) are preset and don't need to be injected as a parameter anymore.
+        Return the function where all the arguments that come from a literal value
+        (instead of a reference built by the DSL) are preset and don't need to be
+        injected as a parameter anymore.
 
         For instance, given:
 

--- a/dagger/dsl/parameter_usage.py
+++ b/dagger/dsl/parameter_usage.py
@@ -26,7 +26,7 @@ class ParameterUsage:
         return self._name
 
     @property
-    def default_value(self) -> T:
+    def default_value(self) -> Union[EmptyDefaultValue, T]:
         """Return the default value of the parameter."""
         return self._default_value
 

--- a/dagger/dsl/parameter_usage.py
+++ b/dagger/dsl/parameter_usage.py
@@ -1,5 +1,5 @@
 """Data structures that represent how parameters are used throughout a DAG defined ."""
-from typing import Any, TypeVar, Optional
+from typing import TypeVar, Union
 
 from dagger.serializer import DefaultSerializer, Serializer
 
@@ -20,8 +20,8 @@ class ParameterUsage:
     def __init__(
         self,
         name: str,
-        default_value: Optional[T] = EmptyDefaultValue,
-        serializer: Optional[Serializer] = DefaultSerializer,
+        default_value: Union[EmptyDefaultValue, T],
+        serializer: Serializer = DefaultSerializer,
     ):
         self._name = name
         self._default_value = default_value

--- a/dagger/dsl/parameter_usage.py
+++ b/dagger/dsl/parameter_usage.py
@@ -2,7 +2,7 @@
 from typing import TypeVar, Union
 
 from dagger.input import EmptyDefaultValue
-from dagger.serializer import DefaultSerializer, Serializer, JSONSerializableType
+from dagger.serializer import DefaultSerializer, JSONSerializableType, Serializer
 
 
 class ParameterUsage:

--- a/dagger/dsl/parameter_usage.py
+++ b/dagger/dsl/parameter_usage.py
@@ -1,7 +1,7 @@
 """Data structures that represent how parameters are used throughout a DAG defined ."""
 from typing import TypeVar, Union
 
-from dagger.input.empty_default_value import EmptyDefaultValue
+from dagger.input import EmptyDefaultValue
 from dagger.serializer import DefaultSerializer, Serializer
 
 T = TypeVar("T")
@@ -51,4 +51,5 @@ class ParameterUsage:
             isinstance(obj, ParameterUsage)
             and self._name == obj._name
             and self._serializer == obj._serializer
+            and self._default_value == obj._default_value
         )

--- a/dagger/dsl/parameter_usage.py
+++ b/dagger/dsl/parameter_usage.py
@@ -1,5 +1,5 @@
 """Data structures that represent how parameters are used throughout a DAG defined ."""
-from typing import TypeVar, Union
+from typing import Union
 
 from dagger.input import EmptyDefaultValue
 from dagger.serializer import DefaultSerializer, JSONSerializableType, Serializer

--- a/dagger/dsl/parameter_usage.py
+++ b/dagger/dsl/parameter_usage.py
@@ -1,19 +1,41 @@
 """Data structures that represent how parameters are used throughout a DAG defined ."""
+from typing import Any, TypeVar, Optional
 
 from dagger.serializer import DefaultSerializer, Serializer
+
+T = TypeVar("T")
+
+
+class EmptyDefaultValue:
+    """ Marker object for that represents a parameter without default value. """
+
+    def __repr__(self) -> str:
+        """Get a human-readable string representation of an empty default value."""
+        return "'None'"
 
 
 class ParameterUsage:
     """Represents the use of a parameters supplied to the DAG."""
 
-    def __init__(self, name: str, serializer: Serializer = DefaultSerializer):
+    def __init__(
+        self,
+        name: str,
+        default_value: Optional[T] = EmptyDefaultValue,
+        serializer: Optional[Serializer] = DefaultSerializer,
+    ):
         self._name = name
+        self._default_value = default_value
         self._serializer = serializer
 
     @property
     def name(self) -> str:
         """Return the name of the parameter."""
         return self._name
+
+    @property
+    def default_value(self) -> T:
+        """Return the default value of the parameter."""
+        return self._default_value
 
     @property
     def serializer(self) -> Serializer:
@@ -28,7 +50,7 @@ class ParameterUsage:
 
     def __repr__(self) -> str:
         """Get a human-readable string representation of this parameter usage."""
-        return f"ParameterUsage(name={self._name}, serializer={self._serializer})"
+        return f"ParameterUsage(name={self._name}, default_value={self._default_value}, serializer={self._serializer})"
 
     def __eq__(self, obj) -> bool:
         """Return true if both objects are equivalent."""

--- a/dagger/dsl/parameter_usage.py
+++ b/dagger/dsl/parameter_usage.py
@@ -2,9 +2,7 @@
 from typing import TypeVar, Union
 
 from dagger.input import EmptyDefaultValue
-from dagger.serializer import DefaultSerializer, Serializer
-
-T = TypeVar("T")
+from dagger.serializer import DefaultSerializer, Serializer, JSONSerializableType
 
 
 class ParameterUsage:
@@ -13,7 +11,9 @@ class ParameterUsage:
     def __init__(
         self,
         name: str,
-        default_value: Union[EmptyDefaultValue, T] = EmptyDefaultValue(),
+        default_value: Union[
+            EmptyDefaultValue, JSONSerializableType
+        ] = EmptyDefaultValue(),
         serializer: Serializer = DefaultSerializer,
     ):
         self._name = name
@@ -26,7 +26,7 @@ class ParameterUsage:
         return self._name
 
     @property
-    def default_value(self) -> Union[EmptyDefaultValue, T]:
+    def default_value(self) -> Union[EmptyDefaultValue, JSONSerializableType]:
         """Return the default value of the parameter."""
         return self._default_value
 

--- a/dagger/dsl/parameter_usage.py
+++ b/dagger/dsl/parameter_usage.py
@@ -1,17 +1,10 @@
 """Data structures that represent how parameters are used throughout a DAG defined ."""
 from typing import TypeVar, Union
 
+from dagger.input.empty_default_value import EmptyDefaultValue
 from dagger.serializer import DefaultSerializer, Serializer
 
 T = TypeVar("T")
-
-
-class EmptyDefaultValue:
-    """ Marker object for that represents a parameter without default value. """
-
-    def __repr__(self) -> str:
-        """Get a human-readable string representation of an empty default value."""
-        return "'None'"
 
 
 class ParameterUsage:
@@ -20,7 +13,7 @@ class ParameterUsage:
     def __init__(
         self,
         name: str,
-        default_value: Union[EmptyDefaultValue, T],
+        default_value: Union[EmptyDefaultValue, T] = EmptyDefaultValue(),
         serializer: Serializer = DefaultSerializer,
     ):
         self._name = name

--- a/dagger/input/__init__.py
+++ b/dagger/input/__init__.py
@@ -3,6 +3,6 @@
 from dagger.input.empty_default_value import EmptyDefaultValue  # noqa
 from dagger.input.from_node_output import FromNodeOutput  # noqa
 from dagger.input.from_param import FromParam  # noqa
+from dagger.input.validators import filter_not_required_inputs  # noqa
 from dagger.input.validators import validate_name  # noqa
 from dagger.input.validators import validate_parameters  # noqa
-from dagger.input.validators import filter_not_required_inputs  # noqa

--- a/dagger/input/__init__.py
+++ b/dagger/input/__init__.py
@@ -3,6 +3,6 @@
 from dagger.input.empty_default_value import EmptyDefaultValue  # noqa
 from dagger.input.from_node_output import FromNodeOutput  # noqa
 from dagger.input.from_param import FromParam  # noqa
-from dagger.input.validators import filter_not_required_inputs  # noqa
 from dagger.input.validators import validate_name  # noqa
 from dagger.input.validators import validate_parameters  # noqa
+from dagger.input.validators import filter_not_required_inputs  # noqa

--- a/dagger/input/__init__.py
+++ b/dagger/input/__init__.py
@@ -1,5 +1,7 @@
 """Inputs for DAGs/Tasks."""
 
+from dagger.input.empty_default_value import EmptyDefaultValue  # noqa
 from dagger.input.from_node_output import FromNodeOutput  # noqa
 from dagger.input.from_param import FromParam  # noqa
 from dagger.input.validators import validate_name  # noqa
+from dagger.input.validators import validate_parameters  # noqa

--- a/dagger/input/__init__.py
+++ b/dagger/input/__init__.py
@@ -3,5 +3,6 @@
 from dagger.input.empty_default_value import EmptyDefaultValue  # noqa
 from dagger.input.from_node_output import FromNodeOutput  # noqa
 from dagger.input.from_param import FromParam  # noqa
+from dagger.input.validators import filter_not_required_inputs  # noqa
 from dagger.input.validators import validate_name  # noqa
 from dagger.input.validators import validate_parameters  # noqa

--- a/dagger/input/__init__.py
+++ b/dagger/input/__init__.py
@@ -3,6 +3,6 @@
 from dagger.input.empty_default_value import EmptyDefaultValue  # noqa
 from dagger.input.from_node_output import FromNodeOutput  # noqa
 from dagger.input.from_param import FromParam  # noqa
-from dagger.input.validators import filter_not_required_inputs  # noqa
+from dagger.input.validators import split_required_and_optional_inputs  # noqa
+from dagger.input.validators import validate_and_clean_parameters  # noqa
 from dagger.input.validators import validate_name  # noqa
-from dagger.input.validators import validate_parameters  # noqa

--- a/dagger/input/empty_default_value.py
+++ b/dagger/input/empty_default_value.py
@@ -1,0 +1,11 @@
+
+class EmptyDefaultValue:
+    """ Marker object for that represents a parameter without default value. """
+
+    def __repr__(self) -> str:
+        """Get a human-readable string representation of an empty default value."""
+        return "'None'"
+
+    def __eq__(self, obj):
+        """Return true if both inputs are equivalent."""
+        return isinstance(obj, EmptyDefaultValue)

--- a/dagger/input/empty_default_value.py
+++ b/dagger/input/empty_default_value.py
@@ -1,6 +1,11 @@
+"""Representation of the value of a parameter without default value."""
+
 
 class EmptyDefaultValue:
-    """ Marker object for that represents a parameter without default value. """
+    """Marker object that represents a parameter without default value.
+
+    This representation is needed to distinguish no default from a None default value.
+    """
 
     def __repr__(self) -> str:
         """Get a human-readable string representation of an empty default value."""

--- a/dagger/input/empty_default_value.py
+++ b/dagger/input/empty_default_value.py
@@ -9,7 +9,7 @@ class EmptyDefaultValue:
 
     def __repr__(self) -> str:
         """Get a human-readable string representation of an empty default value."""
-        return "'None'"
+        return "'EmptyDefaultValue'"
 
     def __eq__(self, obj):
         """Return true if both inputs are equivalent."""

--- a/dagger/input/from_node_output.py
+++ b/dagger/input/from_node_output.py
@@ -1,9 +1,6 @@
 """Input retrieved from the output of another node."""
-from typing import TypeVar
 
 from dagger.serializer import DefaultSerializer, Serializer
-
-T = TypeVar("T")
 
 
 class FromNodeOutput:
@@ -13,7 +10,6 @@ class FromNodeOutput:
         self,
         node: str,
         output: str,
-        default_value: T,
         serializer: Serializer = DefaultSerializer,
     ):
         """
@@ -27,9 +23,6 @@ class FromNodeOutput:
         output
             The name of the output declared by 'node'
 
-        default_value
-            The default value, if any, of the input
-
         serializer
             The Serializer implementation to use to deserialize the input.
 
@@ -40,7 +33,6 @@ class FromNodeOutput:
         """
         self._node_name = node
         self._node_output_name = output
-        self._default_value = default_value
         self._serializer = serializer
 
     @property
@@ -52,11 +44,6 @@ class FromNodeOutput:
     def output(self) -> str:
         """Get the name of the output the input should be retrieved from."""
         return self._node_output_name
-
-    @property
-    def default_value(self) -> T:
-        """Get the default value of the input."""
-        return self._default_value
 
     @property
     def serializer(self) -> Serializer:

--- a/dagger/input/from_node_output.py
+++ b/dagger/input/from_node_output.py
@@ -1,6 +1,9 @@
 """Input retrieved from the output of another node."""
+from typing import TypeVar
 
 from dagger.serializer import DefaultSerializer, Serializer
+
+T = TypeVar("T")
 
 
 class FromNodeOutput:
@@ -10,6 +13,7 @@ class FromNodeOutput:
         self,
         node: str,
         output: str,
+        default_value: T,
         serializer: Serializer = DefaultSerializer,
     ):
         """
@@ -23,6 +27,9 @@ class FromNodeOutput:
         output
             The name of the output declared by 'node'
 
+        default_value
+            The default value, if any, of the input
+
         serializer
             The Serializer implementation to use to deserialize the input.
 
@@ -33,6 +40,7 @@ class FromNodeOutput:
         """
         self._node_name = node
         self._node_output_name = output
+        self._default_value = default_value
         self._serializer = serializer
 
     @property
@@ -44,6 +52,11 @@ class FromNodeOutput:
     def output(self) -> str:
         """Get the name of the output the input should be retrieved from."""
         return self._node_output_name
+
+    @property
+    def default_value(self) -> T:
+        """Get the default value of the input."""
+        return self._default_value
 
     @property
     def serializer(self) -> Serializer:

--- a/dagger/input/from_param.py
+++ b/dagger/input/from_param.py
@@ -1,8 +1,11 @@
 """Input retrieved from the parameters passed to the parent node."""
 
-from typing import Optional
+from typing import Optional, TypeVar
 
+from dagger.dsl.parameter_usage import EmptyDefaultValue
 from dagger.serializer import DefaultSerializer, Serializer
+
+T = TypeVar("T")
 
 
 class FromParam:
@@ -11,6 +14,7 @@ class FromParam:
     def __init__(
         self,
         name: Optional[str] = None,
+        default_value: T = EmptyDefaultValue,
         serializer: Serializer = DefaultSerializer,
     ):
         """
@@ -31,6 +35,7 @@ class FromParam:
         """
         self._serializer = serializer
         self._name = name
+        self._default_value = default_value
 
     @property
     def serializer(self) -> Serializer:
@@ -42,9 +47,14 @@ class FromParam:
         """Get the name the input references, if any."""
         return self._name
 
+    @property
+    def default_value(self) -> T:
+        """Get the default value of the input references, if any."""
+        return self._default_value
+
     def __repr__(self) -> str:
         """Get a human-readable string representation of the input."""
-        return f"FromParam(name={self._name}, serializer={self._serializer})"
+        return f"FromParam(name={self._name}, default_value={self._default_value}, serializer={self._serializer})"
 
     def __eq__(self, obj):
         """Return true if both inputs are equivalent."""

--- a/dagger/input/from_param.py
+++ b/dagger/input/from_param.py
@@ -4,8 +4,7 @@ from typing import Optional, TypeVar, Union
 
 from dagger.input.empty_default_value import EmptyDefaultValue
 from dagger.serializer import DefaultSerializer, Serializer
-
-T = TypeVar("T")
+from dagger.serializer import JSONSerializableType
 
 
 class FromParam:
@@ -14,7 +13,9 @@ class FromParam:
     def __init__(
         self,
         name: Optional[str] = None,
-        default_value: Union[EmptyDefaultValue, T] = EmptyDefaultValue(),
+        default_value: Union[
+            EmptyDefaultValue, JSONSerializableType
+        ] = EmptyDefaultValue(),
         serializer: Serializer = DefaultSerializer,
     ):
         """
@@ -51,7 +52,7 @@ class FromParam:
         return self._name
 
     @property
-    def default_value(self) -> Union[EmptyDefaultValue, T]:
+    def default_value(self) -> Union[EmptyDefaultValue, JSONSerializableType]:
         """Get the default value of the input references, if any."""
         return self._default_value
 

--- a/dagger/input/from_param.py
+++ b/dagger/input/from_param.py
@@ -55,6 +55,10 @@ class FromParam:
         """Get the default value of the input references, if any."""
         return self._default_value
 
+    def has_default_value(self) -> bool:
+        """Return true if the input has a non-empty default value."""
+        return not isinstance(self._default_value, EmptyDefaultValue)
+
     def __repr__(self) -> str:
         """Get a human-readable string representation of the input."""
         return f"FromParam(name={self._name}, default_value={self._default_value}, serializer={self._serializer})"

--- a/dagger/input/from_param.py
+++ b/dagger/input/from_param.py
@@ -1,6 +1,6 @@
 """Input retrieved from the parameters passed to the parent node."""
 
-from typing import Optional, TypeVar, Union
+from typing import Optional, Union
 
 from dagger.input.empty_default_value import EmptyDefaultValue
 from dagger.serializer import DefaultSerializer, JSONSerializableType, Serializer

--- a/dagger/input/from_param.py
+++ b/dagger/input/from_param.py
@@ -2,7 +2,7 @@
 
 from typing import Optional, TypeVar
 
-from dagger.dsl.parameter_usage import EmptyDefaultValue
+from dagger.input.empty_default_value import EmptyDefaultValue
 from dagger.serializer import DefaultSerializer, Serializer
 
 T = TypeVar("T")
@@ -14,7 +14,7 @@ class FromParam:
     def __init__(
         self,
         name: Optional[str] = None,
-        default_value: T = EmptyDefaultValue,
+        default_value: T = EmptyDefaultValue(),
         serializer: Serializer = DefaultSerializer,
     ):
         """
@@ -22,12 +22,15 @@ class FromParam:
 
         Parameters
         ----------
-        serializer
-            The Serializer implementation to use to deserialize the input.
-
         name
             The name of the parameter in the parent node.
             If omitted, it's assumed to be equal to the name given to this input.
+
+        default_value
+            The default value, if any, of the input
+
+        serializer
+            The Serializer implementation to use to deserialize the input.
 
         Returns
         -------
@@ -62,4 +65,5 @@ class FromParam:
             isinstance(obj, FromParam)
             and self._name == obj._name
             and self._serializer == obj._serializer
+            and self._default_value == obj._default_value
         )

--- a/dagger/input/from_param.py
+++ b/dagger/input/from_param.py
@@ -3,8 +3,7 @@
 from typing import Optional, TypeVar, Union
 
 from dagger.input.empty_default_value import EmptyDefaultValue
-from dagger.serializer import DefaultSerializer, Serializer
-from dagger.serializer import JSONSerializableType
+from dagger.serializer import DefaultSerializer, JSONSerializableType, Serializer
 
 
 class FromParam:

--- a/dagger/input/from_param.py
+++ b/dagger/input/from_param.py
@@ -1,6 +1,6 @@
 """Input retrieved from the parameters passed to the parent node."""
 
-from typing import Optional, TypeVar
+from typing import Optional, TypeVar, Union
 
 from dagger.input.empty_default_value import EmptyDefaultValue
 from dagger.serializer import DefaultSerializer, Serializer
@@ -14,7 +14,7 @@ class FromParam:
     def __init__(
         self,
         name: Optional[str] = None,
-        default_value: T = EmptyDefaultValue(),
+        default_value: Union[EmptyDefaultValue, T] = EmptyDefaultValue(),
         serializer: Serializer = DefaultSerializer,
     ):
         """

--- a/dagger/input/from_param.py
+++ b/dagger/input/from_param.py
@@ -51,7 +51,7 @@ class FromParam:
         return self._name
 
     @property
-    def default_value(self) -> T:
+    def default_value(self) -> Union[EmptyDefaultValue, T]:
         """Get the default value of the input references, if any."""
         return self._default_value
 

--- a/dagger/input/validators.py
+++ b/dagger/input/validators.py
@@ -58,7 +58,7 @@ def validate_and_clean_parameters(
     inputs: Mapping[str, Union[FromParam, FromNodeOutput]], params: Mapping[str, Any]
 ) -> Mapping[str, Any]:
     """
-    Validate the parameters supplied to a node and build an exhaustive map of inputs, exclusing any superfluous parameters, and adding any default values that haven't been overridden.
+    Validate the parameters supplied to a node and build an exhaustive map of inputs, excluding any superfluous parameters, and adding any default values that haven't been overridden.
 
     Parameters
     ----------

--- a/dagger/input/validators.py
+++ b/dagger/input/validators.py
@@ -68,7 +68,7 @@ def validate_parameters(
 def filter_not_required_inputs(
     inputs: Mapping[str, Union[FromParam, FromNodeOutput]]
 ) -> Set[str]:
-    """Filters all inputs which have a default value."""
+    """Filter all inputs which have a default value."""
     return {
         name
         for name, input_ in inputs.items()

--- a/dagger/input/validators.py
+++ b/dagger/input/validators.py
@@ -1,5 +1,10 @@
 """Validators applicable to all types of inputs."""
 import re
+import warnings
+from typing import Any, Mapping, Union
+
+from dagger.input import FromNodeOutput, FromParam
+from dagger.input.empty_default_value import EmptyDefaultValue
 
 VALID_NAME_REGEX = r"^[a-zA-Z0-9][a-zA-Z0-9-_]{0,63}$"
 VALID_NAME = re.compile(VALID_NAME_REGEX)
@@ -16,5 +21,50 @@ def validate_name(name: str):
     """
     if not VALID_NAME.match(name):
         raise ValueError(
-            f"'{name}' is not a valid name for an input. Inputs must comply with the regex {VALID_NAME_REGEX}"
+            f"'{name}' is not a valid name for an input. Inputs must comply with the "
+            f"regex {VALID_NAME_REGEX}"
+        )
+
+
+def validate_parameters(
+    inputs: Mapping[str, Union[FromParam, FromNodeOutput]],
+    params: Mapping[str, Any],
+):
+    """
+    Validate a series of parameters against the inputs of a DAG.
+
+    Parameters
+    ----------
+    inputs
+        A mapping of input names to inputs.
+
+    params
+        A mapping of input names to parameters or input values.
+        Input values must be passed in their serialized representation.
+
+    Raises
+    ------
+    ValueError
+        If the set of parameters does not contain all the required inputs.
+    """
+    required_inputs = {
+        name
+        for name, input_ in inputs.items()
+        if not isinstance(input_, FromParam)
+        or input_.default_value == EmptyDefaultValue()
+    }
+    missing_params = required_inputs - params.keys()
+    if missing_params:
+        raise ValueError(
+            f"The parameters supplied to this node were supposed to contain the "
+            f"following parameters: {sorted(list(required_inputs))}. However, only the "
+            f"following parameters were actually supplied: {sorted(list(params))}. We "
+            f"are missing: {sorted(list(missing_params))}."
+        )
+
+    superfluous_params = params.keys() - inputs.keys()
+    if superfluous_params:
+        warnings.warn(
+            f"The following parameters were supplied to this node, but are not "
+            f"necessary: {sorted(list(superfluous_params))}"
         )

--- a/dagger/input/validators.py
+++ b/dagger/input/validators.py
@@ -1,7 +1,7 @@
 """Validators applicable to all types of inputs."""
 import re
 import warnings
-from typing import Any, Mapping, Union
+from typing import Any, Mapping, Set, Union
 
 from dagger.input import FromNodeOutput, FromParam
 from dagger.input.empty_default_value import EmptyDefaultValue
@@ -47,12 +47,7 @@ def validate_parameters(
     ValueError
         If the set of parameters does not contain all the required inputs.
     """
-    required_inputs = {
-        name
-        for name, input_ in inputs.items()
-        if not isinstance(input_, FromParam)
-        or input_.default_value == EmptyDefaultValue()
-    }
+    required_inputs = filter_not_required_inputs(inputs)
     missing_params = required_inputs - params.keys()
     if missing_params:
         raise ValueError(
@@ -68,3 +63,15 @@ def validate_parameters(
             f"The following parameters were supplied to this node, but are not "
             f"necessary: {sorted(list(superfluous_params))}"
         )
+
+
+def filter_not_required_inputs(
+    inputs: Mapping[str, Union[FromParam, FromNodeOutput]]
+) -> Set[str]:
+    """Filters all inputs which have a default value."""
+    return {
+        name
+        for name, input_ in inputs.items()
+        if not isinstance(input_, FromParam)
+        or input_.default_value == EmptyDefaultValue()
+    }

--- a/dagger/runtime/argo/workflow_spec.py
+++ b/dagger/runtime/argo/workflow_spec.py
@@ -4,8 +4,7 @@ from typing import Any, Dict, List, Mapping, Sequence, Union
 
 from dagger.dag import DAG, Node
 from dagger.dag import SupportedInputs as SupportedDAGInputs
-from dagger.dag import validate_parameters
-from dagger.input import FromNodeOutput, FromParam
+from dagger.input import FromNodeOutput, FromParam, validate_parameters
 from dagger.runtime.argo.extra_spec_options import with_extra_spec_options
 from dagger.runtime.argo.workflow import Workflow
 from dagger.serializer import Serializer

--- a/dagger/runtime/argo/workflow_spec.py
+++ b/dagger/runtime/argo/workflow_spec.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Mapping, Sequence, Union
 
 from dagger.dag import DAG, Node
 from dagger.dag import SupportedInputs as SupportedDAGInputs
-from dagger.input import FromNodeOutput, FromParam, validate_parameters
+from dagger.input import FromNodeOutput, FromParam, validate_and_clean_parameters
 from dagger.runtime.argo.extra_spec_options import with_extra_spec_options
 from dagger.runtime.argo.workflow import Workflow
 from dagger.serializer import Serializer
@@ -38,7 +38,7 @@ def workflow_spec(
     ValueError
         If any of the extra_spec_options collides with a property used by the runtime.
     """
-    validate_parameters(inputs=dag.inputs, params=workflow.params)
+    params = validate_and_clean_parameters(dag.inputs, workflow.params)
 
     spec = {
         "entrypoint": BASE_DAG_NAME,
@@ -46,12 +46,12 @@ def workflow_spec(
             node=dag,
             container_image=workflow.container_image,
             container_command=workflow.container_entrypoint_to_dag_cli,
-            params=workflow.params,
+            params=params,
         ),
     }
 
     if workflow.params:
-        spec["arguments"] = _workflow_spec_arguments(workflow.params)
+        spec["arguments"] = _workflow_spec_arguments(params)
 
     spec = with_extra_spec_options(
         original=spec,
@@ -62,7 +62,9 @@ def workflow_spec(
     return spec
 
 
-def _workflow_spec_arguments(params: Mapping[str, Any]) -> Mapping[str, Any]:
+def _workflow_spec_arguments(
+    params: Mapping[str, Any],
+) -> Mapping[str, Any]:
     return {
         "parameters": [
             {"name": param_name, "value": params[param_name]} for param_name in params

--- a/dagger/runtime/cli/invoke_with_locations.py
+++ b/dagger/runtime/cli/invoke_with_locations.py
@@ -1,9 +1,11 @@
 """Command-line Interface to run DAGs or Tasks taking their inputs from files and storing their outputs into files."""
 import tempfile
-from typing import Any, Iterable, List, Mapping
+from typing import Any, Iterable, List, Mapping, Union
 
 import dagger.runtime.local as local
+from dagger import FromNodeOutput, FromParam
 from dagger.dag import DAG
+from dagger.input import filter_not_required_inputs
 from dagger.input.empty_default_value import EmptyDefaultValue
 from dagger.runtime.cli.locations import (
     retrieve_input_from_location,
@@ -55,7 +57,7 @@ def invoke_with_locations(
     output_locations = output_locations or {}
     nested_node = find_nested_node(dag, node_address or [])
 
-    _validate_inputs(nested_node.node.inputs, input_locations.keys())
+    _validate_inputs(nested_node.node.inputs, input_locations)
     _validate_outputs(nested_node.node.outputs.keys(), output_locations.keys())
 
     params = _deserialized_params(nested_node, input_locations)
@@ -80,17 +82,17 @@ def invoke_with_locations(
 
 
 def _validate_inputs(
-    input_names: Iterable[str],
+    inputs: Mapping[str, Union[FromParam, FromNodeOutput]],
     input_locations: Iterable[str],
 ):
     """Validate all the input locations supplied against the inputs the node is expecting."""
-    for input_name, input_value in input_names.items():
-        if (
-            input_name not in input_locations
-            and input_value.default_value == EmptyDefaultValue()
-        ):
+    required_inputs = filter_not_required_inputs(inputs)
+    for input_name in required_inputs:
+        if input_name not in input_locations:
             raise ValueError(
-                f"This node is supposed to receive a pointer to an input named '{input_name}'. However, only the following input pointers were supplied: {sorted(input_locations)}"
+                f"This node is supposed to receive a pointer to an input named "
+                f"'{input_name}'. However, only the following input pointers were "
+                f"supplied: {sorted(input_locations)}"
             )
 
 
@@ -102,7 +104,9 @@ def _validate_outputs(
     for output_name in output_names:
         if output_name not in output_locations:
             raise ValueError(
-                f"This node is supposed to receive a pointer to an output named '{output_name}'. However, only the following output pointers were supplied: {sorted(output_locations)}"
+                f"This node is supposed to receive a pointer to an output named "
+                f"'{output_name}'. However, only the following output pointers were "
+                f"supplied: {sorted(output_locations)}"
             )
 
 
@@ -120,7 +124,8 @@ def _deserialized_params(
             )
         except (FileNotFoundError, PermissionError) as e:
             raise OSError(
-                f"When retrieving input '{input_name}' from the provided location, we got the following error: {str(e)}"
+                f"When retrieving input '{input_name}' from the provided location, we "
+                f"got the following error: {str(e)}"
             ) from e
 
     return params

--- a/dagger/runtime/cli/invoke_with_locations.py
+++ b/dagger/runtime/cli/invoke_with_locations.py
@@ -5,7 +5,7 @@ from typing import Any, Iterable, List, Mapping, Union
 import dagger.runtime.local as local
 from dagger import FromNodeOutput, FromParam
 from dagger.dag import DAG
-from dagger.input import filter_not_required_inputs
+from dagger.input import split_required_and_optional_inputs
 from dagger.runtime.cli.locations import (
     retrieve_input_from_location,
     store_output_in_location,
@@ -85,7 +85,7 @@ def _validate_inputs(
     input_locations: Iterable[str],
 ):
     """Validate all the input locations supplied against the inputs the node is expecting."""
-    required_inputs = filter_not_required_inputs(inputs)
+    required_inputs, _ = split_required_and_optional_inputs(inputs)
     for input_name in required_inputs:
         if input_name not in input_locations:
             raise ValueError(

--- a/dagger/runtime/cli/invoke_with_locations.py
+++ b/dagger/runtime/cli/invoke_with_locations.py
@@ -6,7 +6,6 @@ import dagger.runtime.local as local
 from dagger import FromNodeOutput, FromParam
 from dagger.dag import DAG
 from dagger.input import filter_not_required_inputs
-from dagger.input.empty_default_value import EmptyDefaultValue
 from dagger.runtime.cli.locations import (
     retrieve_input_from_location,
     store_output_in_location,

--- a/dagger/runtime/local/dag.py
+++ b/dagger/runtime/local/dag.py
@@ -113,7 +113,7 @@ def _node_param(
     outputs: Mapping[str, NodeOutputs],
 ) -> Any:
     if isinstance(input_type, FromParam):
-        return params[input_type.name or input_name]
+        return params.get(input_type.name or input_name)
     elif isinstance(outputs[input_type.node], PartitionedOutput):
         return [
             _node_param_from_output(

--- a/dagger/runtime/local/dag.py
+++ b/dagger/runtime/local/dag.py
@@ -4,7 +4,7 @@ import os
 from typing import Any, Dict, Iterable, Mapping, Union
 
 from dagger.dag import DAG, Node
-from dagger.input import FromNodeOutput, FromParam, validate_parameters
+from dagger.input import FromNodeOutput, FromParam, validate_and_clean_parameters
 from dagger.runtime.local.output import load
 from dagger.runtime.local.task import invoke_task
 from dagger.runtime.local.types import (
@@ -36,8 +36,7 @@ def invoke_dag(
     output_path: str,
 ) -> NodeOutputs:
     """Invoke a DAG locally with the specified parameters and dump the serialized outputs on the path provided."""
-    validate_parameters(dag.inputs, params)
-
+    params = validate_and_clean_parameters(dag.inputs, params)
     outputs: Dict[str, NodeExecutions] = {}
 
     sequential_node_order = itertools.chain(*dag.node_execution_order)

--- a/dagger/runtime/local/dag.py
+++ b/dagger/runtime/local/dag.py
@@ -113,7 +113,10 @@ def _node_param(
     outputs: Mapping[str, NodeOutputs],
 ) -> Any:
     if isinstance(input_type, FromParam):
-        return params.get(input_type.name or input_name)
+        if (input_type.name or input_name) not in params:
+            return input_type.default_value
+        else:
+            return params[input_type.name or input_name]
     elif isinstance(outputs[input_type.node], PartitionedOutput):
         return [
             _node_param_from_output(

--- a/dagger/runtime/local/dag.py
+++ b/dagger/runtime/local/dag.py
@@ -3,8 +3,8 @@ import itertools
 import os
 from typing import Any, Dict, Iterable, Mapping, Union
 
-from dagger.dag import DAG, Node, validate_parameters
-from dagger.input import FromNodeOutput, FromParam
+from dagger.dag import DAG, Node
+from dagger.input import FromNodeOutput, FromParam, validate_parameters
 from dagger.runtime.local.output import load
 from dagger.runtime.local.task import invoke_task
 from dagger.runtime.local.types import (

--- a/dagger/runtime/local/task.py
+++ b/dagger/runtime/local/task.py
@@ -1,6 +1,5 @@
 """Run tasks in memory."""
 import os
-import warnings
 from typing import Any, Dict, Iterable, Mapping
 
 from dagger.dag import validate_parameters

--- a/dagger/runtime/local/task.py
+++ b/dagger/runtime/local/task.py
@@ -42,7 +42,10 @@ def _validate_and_filter_inputs(
             f"The following parameters were supplied to the task, but are not necessary: {sorted(list(superfluous_params))}"
         )
 
-    return {input_name: params[input_name] or input_value.default_value for input_name, input_value in inputs.items()}
+    return {
+        input_name: params[input_name] or input_value.default_value
+        for input_name, input_value in inputs.items()
+    }
 
 
 def _serialize_outputs(

--- a/dagger/runtime/local/task.py
+++ b/dagger/runtime/local/task.py
@@ -42,7 +42,7 @@ def _validate_and_filter_inputs(
             f"The following parameters were supplied to the task, but are not necessary: {sorted(list(superfluous_params))}"
         )
 
-    return {input_name: params[input_name] for input_name in inputs}
+    return {input_name: params[input_name] or input_value.default_value for input_name, input_value in inputs.items()}
 
 
 def _serialize_outputs(

--- a/dagger/runtime/local/task.py
+++ b/dagger/runtime/local/task.py
@@ -2,7 +2,7 @@
 import os
 from typing import Any, Dict, Iterable, Mapping
 
-from dagger.dag import validate_parameters
+from dagger.input import validate_parameters
 from dagger.runtime.local.output import dump
 from dagger.runtime.local.types import NodeOutput, NodeOutputs, PartitionedOutput
 from dagger.serializer import SerializationError

--- a/dagger/runtime/local/task.py
+++ b/dagger/runtime/local/task.py
@@ -2,11 +2,11 @@
 import os
 from typing import Any, Dict, Iterable, Mapping
 
-from dagger.input import validate_parameters
+from dagger.input import validate_and_clean_parameters
 from dagger.runtime.local.output import dump
 from dagger.runtime.local.types import NodeOutput, NodeOutputs, PartitionedOutput
 from dagger.serializer import SerializationError
-from dagger.task import SupportedInputs, SupportedOutputs, Task
+from dagger.task import SupportedOutputs, Task
 
 
 def invoke_task(
@@ -15,29 +15,15 @@ def invoke_task(
     output_path: str,
 ) -> NodeOutputs:
     """Invoke a task locally with the specified parameters and dump the serialized outputs on the path provided."""
-    validate_parameters(task.inputs, params)
-    inputs = _filter_inputs(inputs=task.inputs, params=params)
+    params = validate_and_clean_parameters(task.inputs, params)
 
-    return_value = task.func(**inputs)
+    return_value = task.func(**params)
 
     return _serialize_outputs(
         path=output_path,
         outputs=task.outputs,
         return_value=return_value,
     )
-
-
-def _filter_inputs(
-    inputs: Mapping[str, SupportedInputs],
-    params: Mapping[str, Any],
-) -> Mapping[str, Any]:
-
-    return {
-        input_name: params[input_name]
-        if input_name in params
-        else input_value.default_value
-        for input_name, input_value in inputs.items()
-    }
 
 
 def _serialize_outputs(

--- a/dagger/serializer/__init__.py
+++ b/dagger/serializer/__init__.py
@@ -1,6 +1,7 @@
 """Serialization strategies to pass inputs/outputs safely between tasks in a distributed environment."""
 
 from dagger.serializer.as_json import AsJSON  # noqa
+from dagger.serializer.as_json import JSONSerializableType  # noqa
 from dagger.serializer.as_pickle import AsPickle  # noqa
 from dagger.serializer.errors import DeserializationError, SerializationError  # noqa
 from dagger.serializer.protocol import Serializer  # noqa

--- a/dagger/serializer/as_json.py
+++ b/dagger/serializer/as_json.py
@@ -6,14 +6,17 @@ from typing import Any, BinaryIO, Dict, List, Optional, Union
 
 from dagger.serializer.errors import DeserializationError, SerializationError
 
-JSONSerializableType = Union[
+
+# mypy does not currently support recursive types. 
+# It's a known issue: https://github.com/python/mypy/issues/731
+JSONSerializableType = Union[  # type: ignore
     None,
     bool,
     int,
     float,
     str,
-    List["JSONSerializableType"],
-    Dict[str, "JSONSerializableType"],
+    List["JSONSerializableType"],  # type: ignore
+    Dict[str, "JSONSerializableType"],  # type: ignore
 ]
 
 

--- a/dagger/serializer/as_json.py
+++ b/dagger/serializer/as_json.py
@@ -7,7 +7,7 @@ from typing import Any, BinaryIO, Dict, List, Optional, Union
 from dagger.serializer.errors import DeserializationError, SerializationError
 
 
-# mypy does not currently support recursive types. 
+# mypy does not currently support recursive types.
 # It's a known issue: https://github.com/python/mypy/issues/731
 JSONSerializableType = Union[  # type: ignore
     None,

--- a/dagger/serializer/as_json.py
+++ b/dagger/serializer/as_json.py
@@ -6,7 +6,6 @@ from typing import Any, BinaryIO, Dict, List, Optional, Union
 
 from dagger.serializer.errors import DeserializationError, SerializationError
 
-
 # mypy does not currently support recursive types.
 # It's a known issue: https://github.com/python/mypy/issues/731
 JSONSerializableType = Union[  # type: ignore

--- a/dagger/serializer/as_json.py
+++ b/dagger/serializer/as_json.py
@@ -2,9 +2,20 @@
 
 import io
 from json.decoder import JSONDecodeError
-from typing import Any, BinaryIO, Optional
+from typing import Any, BinaryIO, Optional, Union, List, Dict
 
 from dagger.serializer.errors import DeserializationError, SerializationError
+
+
+JSONSerializableType = Union[
+    None,
+    bool,
+    int,
+    float,
+    str,
+    List["JSONSerializableType"],
+    Dict[str, "JSONSerializableType"],
+]
 
 
 class AsJSON:

--- a/dagger/serializer/as_json.py
+++ b/dagger/serializer/as_json.py
@@ -2,10 +2,9 @@
 
 import io
 from json.decoder import JSONDecodeError
-from typing import Any, BinaryIO, Optional, Union, List, Dict
+from typing import Any, BinaryIO, Dict, List, Optional, Union
 
 from dagger.serializer.errors import DeserializationError, SerializationError
-
 
 JSONSerializableType = Union[
     None,

--- a/docs/api/dag.md
+++ b/docs/api/dag.md
@@ -18,7 +18,7 @@
 
 ## validate_parameters
 
-![mkapi](dagger.dag.validate_parameters)
+![mkapi](dagger.input.validate_parameters)
 
 ## CyclicDependencyError
 

--- a/docs/api/dag.md
+++ b/docs/api/dag.md
@@ -16,10 +16,6 @@
 ![mkapi](dagger.dag.DAG.__init__)
 
 
-## validate_parameters
-
-![mkapi](dagger.input.validate_parameters)
-
 ## CyclicDependencyError
 
 ![mkapi](dagger.dag.CyclicDependencyError)

--- a/docs/api/input.md
+++ b/docs/api/input.md
@@ -16,6 +16,22 @@
 ![mkapi](dagger.input.FromNodeOutput)
 
 
+## EmptyDefaultValue
+
+![mkapi](dagger.input.EmptyDefaultValue)
+
+
 ## validate_name
 
 ![mkapi](dagger.input.validate_name)
+
+
+## validate_and_clean_parameters
+
+![mkapi](dagger.input.validate_and_clean_parameters)
+
+
+## split_required_and_optional_inputs
+
+![mkapi](dagger.input.split_required_and_optional_inputs)
+

--- a/docs/api/serializer.md
+++ b/docs/api/serializer.md
@@ -16,6 +16,10 @@
 
 ![mkapi](dagger.serializer.AsJSON)
 
+### JSONSerializableType
+
+![mkapi](dagger.serializer.JSONSerializableType)
+
 
 ### Initialization
 

--- a/docs/api/serializer.md
+++ b/docs/api/serializer.md
@@ -16,10 +16,6 @@
 
 ![mkapi](dagger.serializer.AsJSON)
 
-### JSONSerializableType
-
-![mkapi](dagger.serializer.JSONSerializableType)
-
 
 ### Initialization
 

--- a/docs/api/task.md
+++ b/docs/api/task.md
@@ -11,6 +11,7 @@
 
 ![mkapi](dagger.task.Task)
 
+
 ### Task Initialization
 
 ![mkapi](dagger.task.Task.__init__)

--- a/docs/code_snippets/dag/declarative.py
+++ b/docs/code_snippets/dag/declarative.py
@@ -17,9 +17,7 @@ def measure_model_performance(model, test_dataset):
 
 
 dag = DAG(
-    inputs={
-        "sample_size": FromParam(),
-    },
+    inputs={},
     outputs={
         "performance_report": FromNodeOutput(
             "measure-model-performance", "performance_report"
@@ -29,7 +27,7 @@ dag = DAG(
         "prepare-datasets": Task(
             prepare_datasets,
             inputs={
-                "sample_size": FromParam("sample_size"),
+                "sample_size": FromParam("_hardcoded_sample_size", 10000),
             },
             outputs={
                 "training_dataset": FromKey("training"),

--- a/docs/code_snippets/dag/imperative.py
+++ b/docs/code_snippets/dag/imperative.py
@@ -20,7 +20,7 @@ def measure_model_performance(model, test_dataset):
 
 
 @dsl.DAG()
-def dag(sample_size):
-    datasets = prepare_datasets(sample_size)
+def dag():
+    datasets = prepare_datasets(10000)
     model = train_model(datasets["training"])
     return measure_model_performance(model, datasets["test"])

--- a/docs/code_snippets/dag_composition/declarative.py
+++ b/docs/code_snippets/dag_composition/declarative.py
@@ -15,8 +15,8 @@ def aggregate_fields_b_and_c(dataset: DataSet) -> DataSet:
     return f"{dataset}, with fields b and c aggregated"
 
 
-def calculate_moving_average_for_d(dataset: DataSet) -> DataSet:
-    return f"{dataset}, with moving average for d calculated"
+def calculate_moving_average_for_d(dataset: DataSet, windows: int = 3) -> DataSet:
+    return f"{dataset}, with moving average for d calculated using {windows} windows"
 
 
 def dataset_transformation_dag(dataset_input: FromNodeOutput) -> DAG:

--- a/docs/code_snippets/dag_composition/imperative.py
+++ b/docs/code_snippets/dag_composition/imperative.py
@@ -20,8 +20,8 @@ def aggregate_fields_b_and_c(dataset: DataSet) -> DataSet:
 
 
 @dsl.task()
-def calculate_moving_average_for_d(dataset: DataSet) -> DataSet:
-    return f"{dataset}, with moving average for d calculated"
+def calculate_moving_average_for_d(dataset: DataSet, windows: int = 3) -> DataSet:
+    return f"{dataset}, with moving average for d calculated using {windows} windows"
 
 
 @dsl.DAG()

--- a/docs/code_snippets/default_hardcoded_values/imperative.py
+++ b/docs/code_snippets/default_hardcoded_values/imperative.py
@@ -1,0 +1,16 @@
+from dagger import dsl
+
+
+@dsl.task()
+def add(x, y, z):
+    return f"{x}-{y}-{z}"
+
+
+@dsl.DAG()
+def nested_dag(a, b=2, c=3):
+    return add(a, b, c)
+
+
+@dsl.DAG()
+def dag(a=10):
+    return nested_dag(a, c=20)

--- a/docs/code_snippets/default_hardcoded_values/imperative.py
+++ b/docs/code_snippets/default_hardcoded_values/imperative.py
@@ -7,10 +7,10 @@ def add(x, y, z):
 
 
 @dsl.DAG()
-def nested_dag(a, b=2, c=3):
+def nested_d(a, b=2, c=3):
     return add(a, b, c)
 
 
 @dsl.DAG()
-def dag(a=10):
-    return nested_dag(a, c=20)
+def d(a=10):
+    return nested_d(a, c=20)

--- a/docs/code_snippets/default_values/imperative.py
+++ b/docs/code_snippets/default_values/imperative.py
@@ -1,0 +1,11 @@
+from dagger import dsl
+
+
+@dsl.task()
+def sum(a, b=2):
+    return a + b
+
+
+@dsl.DAG()
+def d(x=1):
+    return sum(x)

--- a/docs/code_snippets/hardcoded_values/imperative.py
+++ b/docs/code_snippets/hardcoded_values/imperative.py
@@ -1,0 +1,11 @@
+from dagger import dsl
+
+
+@dsl.task()
+def sum(a, b=2):
+    return a + b
+
+
+@dsl.DAG()
+def d(x=1):
+    return sum(x, 3)

--- a/docs/code_snippets/quick_start.py
+++ b/docs/code_snippets/quick_start.py
@@ -13,7 +13,7 @@ def generate_numbers(seed):
 
 
 @dsl.task()
-def raise_number(n, exponent):
+def raise_number(n, exponent=2):
     print(f"Raising {n} to a power of {exponent}")
     return n ** exponent
 

--- a/docs/code_snippets/quick_start.py
+++ b/docs/code_snippets/quick_start.py
@@ -13,7 +13,7 @@ def generate_numbers(seed):
 
 
 @dsl.task()
-def raise_number(n, exponent=2):
+def raise_number(n, exponent):
     print(f"Raising {n} to a power of {exponent}")
     return n ** exponent
 
@@ -25,7 +25,7 @@ def sum_numbers(numbers):
 
 
 @dsl.DAG()
-def map_reduce_pipeline(seed, exponent):
+def map_reduce_pipeline(seed, exponent=2):
     numbers = generate_numbers(seed)
 
     raised_numbers = []

--- a/docs/code_snippets/quick_start/build_dag.py
+++ b/docs/code_snippets/quick_start/build_dag.py
@@ -1,0 +1,5 @@
+from dagger import dsl
+
+from .quick_start import map_reduce_pipeline
+
+dag = dsl.build(map_reduce_pipeline)

--- a/docs/code_snippets/quick_start/invoke_dag.py
+++ b/docs/code_snippets/quick_start/invoke_dag.py
@@ -1,0 +1,6 @@
+from dagger.runtime.local import invoke
+
+from .build_dag import dag
+
+result = invoke(dag, params={"seed": 1, "exponent": 2})
+print(f"The final result was {result}")

--- a/docs/code_snippets/quick_start/invoke_dag_with_defaults.py
+++ b/docs/code_snippets/quick_start/invoke_dag_with_defaults.py
@@ -1,0 +1,6 @@
+from dagger.runtime.local import invoke
+
+from .build_dag import dag
+
+result = invoke(dag, params={"seed": 1})
+print(f"The final result was {result}")

--- a/docs/code_snippets/quick_start/quick_start.py
+++ b/docs/code_snippets/quick_start/quick_start.py
@@ -35,6 +35,7 @@ def map_reduce_pipeline(seed, exponent=2):
 
     return sum_numbers(raised_numbers)
 
+
 dag = dsl.build(map_reduce_pipeline)
 result = invoke(dag, params={"seed": 1})
 print(f"The final result was {result}")

--- a/docs/code_snippets/quick_start/quick_start.py
+++ b/docs/code_snippets/quick_start/quick_start.py
@@ -34,8 +34,3 @@ def map_reduce_pipeline(seed, exponent=2):
         raised_numbers.append(raise_number(n, exponent))
 
     return sum_numbers(raised_numbers)
-
-
-dag = dsl.build(map_reduce_pipeline)
-result = invoke(dag, params={"seed": 1})
-print(f"The final result was {result}")

--- a/docs/code_snippets/quick_start/quick_start.py
+++ b/docs/code_snippets/quick_start/quick_start.py
@@ -1,6 +1,7 @@
 import random
 
 from dagger import dsl
+from dagger.runtime.local import invoke
 
 
 @dsl.task()
@@ -33,3 +34,7 @@ def map_reduce_pipeline(seed, exponent=2):
         raised_numbers.append(raise_number(n, exponent))
 
     return sum_numbers(raised_numbers)
+
+dag = dsl.build(map_reduce_pipeline)
+result = invoke(dag, params={"seed": 1})
+print(f"The final result was {result}")

--- a/docs/dictionary.txt
+++ b/docs/dictionary.txt
@@ -54,6 +54,8 @@ parallelize
 parallelizing
 parallelization
 json
+JSONSerializableType
+EmptyDefaultValue
 boolean
 CSV
 CSVs

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -19,7 +19,7 @@ pip install py-dagger
 The following piece of code demonstrates how to build a DAG that performs a map-reduce operation on a series of numbers:
 
 ```python
---8<-- "docs/code_snippets/quick_start.py"
+--8<-- "docs/code_snippets/quick_start/quick_start.py"
 ```
 
 Let's take it step by step. First, we use the `dagger.dsl.task` decorator to define different tasks. Tasks in _Dagger_ are just Python functions. In this case, we have 3 tasks:
@@ -72,7 +72,7 @@ Equivalently, because the parameter `exponent` has a default value of 2, you can
 ```python
 from dagger.runtime.local import invoke
 
-result = invoke(dag, params={"seed": 1})
+result = invoke(map_reduce_pipeline, params={"seed": 1})
 print(f"The final result was {result}")
 ```
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -25,7 +25,7 @@ The following piece of code demonstrates how to build a DAG that performs a map-
 Let's take it step by step. First, we use the `dagger.dsl.task` decorator to define different tasks. Tasks in _Dagger_ are just Python functions. In this case, we have 3 tasks:
 
 - `generate_numbers()` returns a list of numbers. The length of the list varies dynamically.
-- `raise_number(n, exponent)` receives a number and an exponent, and returns `n^exponent`.
+- `raise_number(n, exponent)` receives a number and an exponent, which has a default value, 2, and returns `n^exponent`.
 - `sum_numbers(numbers)` receives a list of numbers and returns the sum of all of them.
 
 Next, we use the `dagger.dsl.DAG` decorator on another function that __invokes all the tasks we've defined and connects their inputs/outputs__.
@@ -65,7 +65,16 @@ result = invoke(dag, params={"seed": 1, "exponent": 2})
 print(f"The final result was {result}")
 ```
 
-After this, you should see the results of the DAG printed to your screen.
+After this, you should see the results of the DAG printed to your screen. 
+
+Equivalently, because the parameter `exponent` has a default value of 2, you can omit passing the value 2 when invoking the DAG:
+
+```python
+from dagger.runtime.local import invoke
+
+result = invoke(dag, params={"seed": 1})
+print(f"The final result was {result}")
+```
 
 
 ### Other Runtimes

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -46,7 +46,7 @@ def map_reduce_pipeline(exponent):
 After defining how our DAG should behave using a function decorated by `dagger.dsl.DAG`, we will need to use `dagger.dsl.build` to __transform it into a `dagger.DAG` data structure__, like this:
 
 ```python
-dag = dsl.build(map_reduce_pipeline)
+--8<-- "docs/code_snippets/quick_start/build_dag.py"
 ```
 
 The variable `dag` now contains our pipeline expressed as a collection of data structures. These data structures validate that our DAG has been built correctly, and allow us to run it using one of the available runtimes.
@@ -59,10 +59,7 @@ The final step will be to test our DAG locally using the `dagger.runtime.local`.
 Just do:
 
 ```python
-from dagger.runtime.local import invoke
-
-result = invoke(dag, params={"seed": 1, "exponent": 2})
-print(f"The final result was {result}")
+--8<-- "docs/code_snippets/quick_start/invoke_dag.py"
 ```
 
 After this, you should see the results of the DAG printed to your screen. 
@@ -70,10 +67,7 @@ After this, you should see the results of the DAG printed to your screen.
 Equivalently, because the parameter `exponent` has a default value of 2, you can omit passing the value 2 when invoking the DAG:
 
 ```python
-from dagger.runtime.local import invoke
-
-result = invoke(map_reduce_pipeline, params={"seed": 1})
-print(f"The final result was {result}")
+--8<-- "docs/code_snippets/quick_start/invoke_dag_with_defaults.py"
 ```
 
 

--- a/docs/user-guide/dsl.md
+++ b/docs/user-guide/dsl.md
@@ -81,7 +81,7 @@ You can also use hardcoded values for tasks and DAGs. Modifying a bit the previo
 --8<-- "docs/code_snippets/hardcoded_values/imperative.py"
 ```
 
-A more sophisticated example, a nested DAG with both default and hardcoded values, is shown below. In this case, the dag return the string `"10-2-20"`.
+A more sophisticated example, a nested DAG with both default and hardcoded values, is shown below. In this case, running the DAG returns the string `"10-2-20"`.
 
 ```python
 --8<-- "docs/code_snippets/default_hardcoded_values/imperative.py"

--- a/docs/user-guide/dsl.md
+++ b/docs/user-guide/dsl.md
@@ -69,19 +69,19 @@ This may or may not be what you intended.
 
 ## Default Values and Hardcoded Values
 
-When defining DAGs and tasks, one can make use of python's default values. For example, the input of the DAG shown below has a default value, 1. The task `sum` has a default value, 2, for its second parameter, `b`. And this makes the DAG return 3 when invoked, if no arguments are passed.
+When defining DAGs and tasks, you can make use of python's default values. For example, the input of the DAG shown below has a default value, 1. The task `sum` has a default value, 2, for its second parameter, `b`. And this makes the DAG return 3 when invoked, if no arguments are passed.
 
 ```python
 --8<-- "docs/code_snippets/default_values/imperative.py"
 ```
 
-One can also use hardcoded values for tasks and DAGs. Modifying a bit the previous example, `b` has now a hardcoded value, 3, which is used in place of its default value, 2. This makes now return 3 when invoked, if no arguments are passed.
+You can also use hardcoded values for tasks and DAGs. Modifying a bit the previous example, `b` has now a hardcoded value, 3, which is used in place of its default value, 2. Now, this makes the DAG return 4 when invoked, if no arguments are passed.
 
 ```python
 --8<-- "docs/code_snippets/hardcoded_values/imperative.py"
 ```
 
-A more sophisticated example, a nested DAG with both default and hardcoded values, is shown below.
+A more sophisticated example, a nested DAG with both default and hardcoded values, is shown below. In this case, the dag return the string `"10-2-20"`.
 
 ```python
 --8<-- "docs/code_snippets/default_hardcoded_values/imperative.py"
@@ -104,7 +104,6 @@ Like with all domain-specific languages, __the number of things you can do insid
 - Add all the results of a partitioned node in a list and pass that list to a fan-in node.
 - Return multiple outputs from the DAG by returning a dictionary of `#!python str -> node_output`.
 - Parameter defaults for tasks, e.g. `#!python def my_task(a, b=2)` will use the default value `2` if `b` is not passed. The same is true for DAG parameters.
-- Pass hardcoded values to a DAG's task or another DAG, e.g. when a nested DAG has two parameters and one is hardcoded in the main DAG.
 
 
 ## ⛔ Limitations

--- a/docs/user-guide/dsl.md
+++ b/docs/user-guide/dsl.md
@@ -67,6 +67,29 @@ This may or may not be what you intended.
 !!! note
     Mixing decorated and undecorated functions may certainly be useful. __What's important is that you are able to distinguish between the things that will happen at build time and the things that will happen at runtime__.
 
+## Default Values and Hardcoded Values
+
+When defining DAGs and tasks, one can make use of python's default values. For example, the input of the DAG shown below has a default value, 1. The task `sum` has a default value, 2, for its second parameter, `b`. And this makes the DAG return 3 when invoked, if no arguments are passed.
+
+```python
+--8<-- "docs/code_snippets/default_values/imperative.py"
+```
+
+One can also use hardcoded values for tasks and DAGs. Modifying a bit the previous example, `b` has now a hardcoded value, 3, which is used in place of its default value, 2. This makes now return 3 when invoked, if no arguments are passed.
+
+```python
+--8<-- "docs/code_snippets/hardcoded_values/imperative.py"
+```
+
+A more sophisticated example, a nested DAG with both default and hardcoded values, is shown below.
+
+```python
+--8<-- "docs/code_snippets/default_hardcoded_values/imperative.py"
+```
+
+
+
+
 
 ## Capabilities
 
@@ -80,6 +103,8 @@ Like with all domain-specific languages, __the number of things you can do insid
 - Iterate over the results of an invocation to parallelize the execution of a node.
 - Add all the results of a partitioned node in a list and pass that list to a fan-in node.
 - Return multiple outputs from the DAG by returning a dictionary of `#!python str -> node_output`.
+- Parameter defaults for tasks, e.g. `#!python def my_task(a, b=2)` will use the default value `2` if `b` is not passed. The same is true for DAG parameters.
+- Pass hardcoded values to a DAG's task or another DAG, e.g. when a nested DAG has two parameters and one is hardcoded in the main DAG.
 
 
 ## ⛔ Limitations
@@ -89,7 +114,6 @@ Technically speaking, anything that hasn't been listed as a capability in the pr
 That said, there are some extra limitations to keep in mind when using the DSL:
 
 - As far as we know, Python is not able to inspect the name of the local variable that holds a value. Therefore, when you assign the output of a task to a variable `#!python my_var = my_task()` and use it from `#!python another_task(my_var, my_var["my-key"], my_var.my_attr)`, the DAG you build from the DSL will name the outputs of `my_task`: `"return_value"`, `"key_my-key"` and `"property_my_attr"`.
-- __Parameter defaults are ignored by the DSL__. A task with the signature `#!python def my_task(a, b=2)` will still expect `b` to be passed as a parameter every time it's used. The same is true for DAG parameters. This may change in the future, if [this feature request](https://github.com/larribas/dagger/issues/35) is implemented.
 - __Only the outputs that are used by other tasks will be exported__. The rest will be omitted. If you assign the output of a task to a variable (`#!python output = my_task()`), but don't use the variable `output` again, _Dagger_ will assume you don't care about the output of that task. The task will still be executed, of course, but you may find the artifact not being saved in a runtime such as _Argo Workflows_.
 
 

--- a/tests/dag/test_dag.py
+++ b/tests/dag/test_dag.py
@@ -650,7 +650,7 @@ def test__validate_parameters__when_input_is_missing():
 
     assert (
         str(e.value)
-        == "The parameters supplied to this DAG were supposed to contain the following parameters: ['a', 'b', 'c']. However, only the following parameters were actually supplied: ['a', 'c']. We are missing: ['b']."
+        == "The parameters supplied to this node were supposed to contain the following parameters: ['a', 'b', 'c']. However, only the following parameters were actually supplied: ['a', 'c']. We are missing: ['b']."
     )
 
 
@@ -671,5 +671,5 @@ def test__validate_parameters__when_param_is_superfluous():
         assert len(w) == 1
         assert (
             str(w[0].message)
-            == "The following parameters were supplied to this DAG, but are not necessary: ['y', 'z']"
+            == "The following parameters were supplied to this node, but are not necessary: ['y', 'z']"
         )

--- a/tests/dag/test_dag.py
+++ b/tests/dag/test_dag.py
@@ -231,6 +231,18 @@ def test__init__with_mismatched_inputs_from_param():
     )
 
 
+def test__init__with_unretrievable_node_inputs_that_have_a_default_value():
+    DAG(
+        nodes={
+            "my-node": Task(
+                lambda x: 1,
+                inputs=dict(x=FromParam("x", default_value=2)),
+            ),
+        },
+    )
+    # We are testing that no validation exceptions are raised
+
+
 def test__init__with_a_node_that_references_an_existing_dag_input_explicitly():
     DAG(
         nodes={

--- a/tests/docs/test_dag_composition.py
+++ b/tests/docs/test_dag_composition.py
@@ -6,7 +6,7 @@ from dagger.runtime.local import invoke
 
 def test_declarative():
     assert invoke(declarative.dag) == {
-        "dataset": "original dataset, with field a encoded, with fields b and c aggregated, with moving average for d calculated",
+        "dataset": "original dataset, with field a encoded, with fields b and c aggregated, with moving average for d calculated using 3 windows",
     }
 
 

--- a/tests/docs/test_default_hardcoded_values.py
+++ b/tests/docs/test_default_hardcoded_values.py
@@ -1,0 +1,8 @@
+from docs.code_snippets.default_hardcoded_values.imperative import d
+from dagger import dsl
+from dagger.runtime.local import invoke
+
+
+def test__d__returns_3():
+    dag = dsl.build(d)
+    assert invoke(dag) == {"return_value": "10-2-20"}

--- a/tests/docs/test_default_hardcoded_values.py
+++ b/tests/docs/test_default_hardcoded_values.py
@@ -1,6 +1,6 @@
-from docs.code_snippets.default_hardcoded_values.imperative import d
 from dagger import dsl
 from dagger.runtime.local import invoke
+from docs.code_snippets.default_hardcoded_values.imperative import d
 
 
 def test__d__returns_3():

--- a/tests/docs/test_default_hardcoded_values.py
+++ b/tests/docs/test_default_hardcoded_values.py
@@ -3,6 +3,6 @@ from dagger.runtime.local import invoke
 from docs.code_snippets.default_hardcoded_values.imperative import d
 
 
-def test__d__returns_3():
+def test__d__returns_correct_value():
     dag = dsl.build(d)
     assert invoke(dag) == {"return_value": "10-2-20"}

--- a/tests/docs/test_default_values.py
+++ b/tests/docs/test_default_values.py
@@ -1,0 +1,8 @@
+from docs.code_snippets.default_values.imperative import d
+from dagger import dsl
+from dagger.runtime.local import invoke
+
+
+def test__d__returns_3():
+    dag = dsl.build(d)
+    assert invoke(dag) == {"return_value": 3}

--- a/tests/docs/test_default_values.py
+++ b/tests/docs/test_default_values.py
@@ -1,6 +1,6 @@
-from docs.code_snippets.default_values.imperative import d
 from dagger import dsl
 from dagger.runtime.local import invoke
+from docs.code_snippets.default_values.imperative import d
 
 
 def test__d__returns_3():

--- a/tests/docs/test_hardcoded_values.py
+++ b/tests/docs/test_hardcoded_values.py
@@ -1,0 +1,8 @@
+from docs.code_snippets.hardcoded_values.imperative import d
+from dagger import dsl
+from dagger.runtime.local import invoke
+
+
+def test__d__returns_4():
+    dag = dsl.build(d)
+    assert invoke(dag) == {"return_value": 4}

--- a/tests/docs/test_hardcoded_values.py
+++ b/tests/docs/test_hardcoded_values.py
@@ -1,6 +1,6 @@
-from docs.code_snippets.hardcoded_values.imperative import d
 from dagger import dsl
 from dagger.runtime.local import invoke
+from docs.code_snippets.hardcoded_values.imperative import d
 
 
 def test__d__returns_4():

--- a/tests/docs/test_quick_start.py
+++ b/tests/docs/test_quick_start.py
@@ -1,5 +1,10 @@
 from dagger import dsl
 from dagger.runtime.local import invoke
+from docs.code_snippets.quick_start.build_dag import dag
+from docs.code_snippets.quick_start.invoke_dag import result
+from docs.code_snippets.quick_start.invoke_dag_with_defaults import (
+    result as result_defaults,
+)
 from docs.code_snippets.quick_start.quick_start import map_reduce_pipeline
 
 
@@ -8,13 +13,14 @@ def test_build():
     # Raises no exceptions
 
 
+def test_invoke_dag():
+    res = invoke(dag, params={"seed": 1, "exponent": 2})
+    assert res == {"return_value": 91}
+
+
 def test_invoke():
-    dag = dsl.build(map_reduce_pipeline)
-    result = invoke(dag, params={"seed": 1, "exponent": 2})
     assert result == {"return_value": 91}
 
 
 def test_invoke_with_default():
-    dag = dsl.build(map_reduce_pipeline)
-    result = invoke(dag, params={"seed": 1})
-    assert result == {"return_value": 91}
+    assert result_defaults == {"return_value": 91}

--- a/tests/docs/test_quick_start.py
+++ b/tests/docs/test_quick_start.py
@@ -1,6 +1,6 @@
 from dagger import dsl
 from dagger.runtime.local import invoke
-from docs.code_snippets.quick_start import map_reduce_pipeline
+from docs.code_snippets.quick_start.quick_start import map_reduce_pipeline
 
 
 def test_build():
@@ -12,3 +12,10 @@ def test_invoke():
     dag = dsl.build(map_reduce_pipeline)
     result = invoke(dag, params={"seed": 1, "exponent": 2})
     assert result == {"return_value": 91}
+    
+    
+def test_invoke_with_default():
+    dag = dsl.build(map_reduce_pipeline)
+    result = invoke(dag, params={"seed": 1})
+    assert result == {"return_value": 91}
+    

--- a/tests/docs/test_quick_start.py
+++ b/tests/docs/test_quick_start.py
@@ -12,10 +12,9 @@ def test_invoke():
     dag = dsl.build(map_reduce_pipeline)
     result = invoke(dag, params={"seed": 1, "exponent": 2})
     assert result == {"return_value": 91}
-    
-    
+
+
 def test_invoke_with_default():
     dag = dsl.build(map_reduce_pipeline)
     result = invoke(dag, params={"seed": 1})
     assert result == {"return_value": 91}
-    

--- a/tests/dsl/test_black_box.py
+++ b/tests/dsl/test_black_box.py
@@ -14,7 +14,6 @@ import dagger.dsl as dsl
 from dagger.dag import DAG
 from dagger.input import FromNodeOutput, FromParam
 from dagger.output import FromKey, FromReturnValue
-from dagger.runtime.local import invoke
 from dagger.serializer import AsJSON, AsPickle
 from dagger.task import Task
 from tests.dsl.verification import verify_dags_are_equivalent
@@ -906,4 +905,3 @@ def test__dag__with_default_value():
             },
         ),
     )
-    assert invoke(dag)["return_value"] == 5

--- a/tests/dsl/test_black_box.py
+++ b/tests/dsl/test_black_box.py
@@ -777,7 +777,6 @@ def test__build__nested_map_reduce():
             ]
         )
 
-
     verify_dags_are_equivalent(
         dsl.build(dag),
         DAG(

--- a/tests/dsl/test_black_box.py
+++ b/tests/dsl/test_black_box.py
@@ -926,4 +926,3 @@ def test__dag__dag_composition_with_default():
 
     dag = dsl.build(my_dag)
     pass
-

--- a/tests/dsl/test_black_box.py
+++ b/tests/dsl/test_black_box.py
@@ -14,7 +14,6 @@ import dagger.dsl as dsl
 from dagger.dag import DAG
 from dagger.input import FromNodeOutput, FromParam
 from dagger.output import FromKey, FromReturnValue
-from dagger.runtime.local import invoke
 from dagger.serializer import AsJSON, AsPickle
 from dagger.task import Task
 from tests.dsl.verification import verify_dags_are_equivalent

--- a/tests/dsl/test_black_box.py
+++ b/tests/dsl/test_black_box.py
@@ -906,4 +906,4 @@ def test__dag__with_default_value():
             },
         ),
     )
-    invoke(dag)
+    assert invoke(dag)["return_value"] == 5

--- a/tests/dsl/test_black_box.py
+++ b/tests/dsl/test_black_box.py
@@ -138,11 +138,11 @@ def test__build__input_from_param():
     )
 
 
-def test__build__input_from_literal_value():
+def test__build__input_from_hardcoded_value():
     class ArbitraryObject:
         pass
 
-    literal_values = [
+    hardcoded_values = [
         "string literal",
         2,
         5.5,
@@ -152,18 +152,40 @@ def test__build__input_from_literal_value():
     ]
 
     @dsl.task()
-    def inspect(hello, value):
-        return f"{hello} {value} of type {type(value).__name__}"
+    def inspect(hello, subject):
+        return f"{hello} {subject} of type {type(subject).__name__}"
 
-    @dsl.DAG()
-    def dag(hello):
-        for value in literal_values:
-            inspect(hello="hello...", value=value)
+    for hardcoded_value in hardcoded_values:
 
-    for i, value in enumerate(literal_values):
-        assert (
-            dsl.build(dag).nodes[f"inspect-{i + 1}"].func()
-            == f"hello... {value} of type {type(value).__name__}"
+        @dsl.DAG()
+        def dag(hello):
+            return inspect(hello=hello, subject=hardcoded_value)
+
+        verify_dags_are_equivalent(
+            dsl.build(dag),
+            DAG(
+                inputs={
+                    "hello": FromParam("hello"),
+                },
+                outputs={
+                    "return_value": FromNodeOutput("inspect", "return_value"),
+                },
+                nodes={
+                    "inspect": Task(
+                        inspect.func,
+                        inputs={
+                            "hello": FromParam("hello"),
+                            "subject": FromParam(
+                                "_hardcoded_value_subject",
+                                default_value=hardcoded_value,
+                            ),
+                        },
+                        outputs={
+                            "return_value": FromReturnValue(),
+                        },
+                    ),
+                },
+            ),
         )
 
 
@@ -888,20 +910,18 @@ def test__dag__with_default_value():
         return a
 
     @dsl.DAG()
-    def d(x=3):
+    def dag(x=3):
         return f(x)
 
-    dag = dsl.build(d)
-
     verify_dags_are_equivalent(
-        dag,
+        dsl.build(dag),
         DAG(
-            inputs={"x": FromParam("x", 3)},
+            inputs={"x": FromParam("x", default_value=3)},
             outputs={"return_value": FromNodeOutput("f", "return_value")},
             nodes={
                 "f": Task(
                     f.func,
-                    inputs={"a": FromParam("x", 3)},
+                    inputs={"a": FromParam("x")},
                     outputs={"return_value": FromReturnValue()},
                 )
             },
@@ -909,43 +929,52 @@ def test__dag__with_default_value():
     )
 
 
-def test__dag__dag_composition_with_default():
+def test__dag__with_default_values_for_nested_dags():
     @dsl.task()
-    def identity(x):
-        return x
+    def add(x, y, z):
+        return f"{x}-{y}-{z}"
 
     @dsl.DAG()
-    def my_sub_dag(a, b=2, c=3):
-        return {
-            "a": identity(a),
-            "b": identity(b),
-            "c": identity(c),
-        }
+    def nested_dag(a, b=2, c=3):
+        return add(a, b, c)
 
     @dsl.DAG()
-    def my_dag(a=10):
-        return my_sub_dag(a, c=20)
+    def dag(a=10):
+        return nested_dag(a, c=20)
 
-    dag = dsl.build(my_dag)
-    pass
-
-
-def test__dag__dag_composition_with_pathological_default():
-    @dsl.task()
-    def identity(x):
-        return x
-
-    @dsl.DAG()
-    def my_sub_dag(a, b=2, c=3):
-        return {
-            "a": identity(a),
-            "b": identity(b),
-            "c": identity(c),
-        }
-
-    @dsl.DAG()
-    def my_dag(c=10):
-        return my_sub_dag(a=10, c=20)
-
-    dag = dsl.build(my_dag)
-    pass
+    verify_dags_are_equivalent(
+        dsl.build(dag),
+        DAG(
+            inputs={
+                "a": FromParam("a", default_value=10),
+            },
+            outputs={
+                "return_value": FromNodeOutput("nested-dag", "return_value"),
+            },
+            nodes={
+                "nested-dag": DAG(
+                    inputs={
+                        "a": FromParam("a"),
+                        "b": FromParam("_default_value_b", default_value=2),
+                        "c": FromParam("_hardcoded_value_c", default_value=20),
+                    },
+                    outputs={
+                        "return_value": FromNodeOutput("add", "return_value"),
+                    },
+                    nodes={
+                        "add": Task(
+                            add.func,
+                            inputs={
+                                "x": FromParam("a"),
+                                "y": FromParam("b"),
+                                "z": FromParam("c"),
+                            },
+                            outputs={
+                                "return_value": FromReturnValue(),
+                            },
+                        ),
+                    },
+                ),
+            },
+        ),
+    )

--- a/tests/dsl/test_black_box.py
+++ b/tests/dsl/test_black_box.py
@@ -777,10 +777,9 @@ def test__build__nested_map_reduce():
             ]
         )
 
-    build_dag = dsl.build(dag)
 
     verify_dags_are_equivalent(
-        build_dag,
+        dsl.build(dag),
         DAG(
             inputs={
                 "exponent": FromParam("exponent"),

--- a/tests/dsl/test_black_box.py
+++ b/tests/dsl/test_black_box.py
@@ -14,6 +14,7 @@ import dagger.dsl as dsl
 from dagger.dag import DAG
 from dagger.input import FromNodeOutput, FromParam
 from dagger.output import FromKey, FromReturnValue
+from dagger.runtime.local import invoke
 from dagger.serializer import AsJSON, AsPickle
 from dagger.task import Task
 from tests.dsl.verification import verify_dags_are_equivalent
@@ -899,7 +900,7 @@ def test__dag__with_default_value():
             nodes={
                 "f": Task(
                     f.func,
-                    inputs={"a": FromParam("x", default_value=3)},
+                    inputs={"a": FromParam("x", 3)},
                     outputs={"return_value": FromReturnValue()},
                 )
             },

--- a/tests/dsl/test_black_box.py
+++ b/tests/dsl/test_black_box.py
@@ -755,8 +755,10 @@ def test__build__nested_map_reduce():
             ]
         )
 
+    build_dag = dsl.build(dag)
+
     verify_dags_are_equivalent(
-        dsl.build(dag),
+        build_dag,
         DAG(
             inputs={
                 "exponent": FromParam("exponent"),
@@ -908,6 +910,27 @@ def test__dag__with_default_value():
 
 
 def test__dag__dag_composition_with_default():
+    @dsl.task()
+    def identity(x):
+        return x
+
+    @dsl.DAG()
+    def my_sub_dag(a, b=2, c=3):
+        return {
+            "a": identity(a),
+            "b": identity(b),
+            "c": identity(c),
+        }
+
+    @dsl.DAG()
+    def my_dag(a=10):
+        return my_sub_dag(a, c=20)
+
+    dag = dsl.build(my_dag)
+    pass
+
+
+def test__dag__dag_composition_with_pathological_default():
     @dsl.task()
     def identity(x):
         return x

--- a/tests/dsl/test_black_box.py
+++ b/tests/dsl/test_black_box.py
@@ -882,8 +882,8 @@ def test__build__nested_for_loops():
 
 def test__dag__with_default_value():
     @dsl.task()
-    def f(a, b=2):
-        return a + b
+    def f(a):
+        return a
 
     @dsl.DAG()
     def d(x=3):
@@ -905,3 +905,25 @@ def test__dag__with_default_value():
             },
         ),
     )
+
+
+def test__dag__dag_composition_with_default():
+    @dsl.task()
+    def identity(x):
+        return x
+
+    @dsl.DAG()
+    def my_sub_dag(a, b=2, c=3):
+        return {
+            "a": identity(a),
+            "b": identity(b),
+            "c": identity(c),
+        }
+
+    @dsl.DAG()
+    def my_dag(c=10):
+        return my_sub_dag(a=10, c=20)
+
+    dag = dsl.build(my_dag)
+    pass
+

--- a/tests/dsl/test_dag_parent.py
+++ b/tests/dsl/test_dag_parent.py
@@ -1,0 +1,26 @@
+from dagger.dsl.dag_parent import DAGParent
+from dagger.dsl.parameter_usage import ParameterUsage
+
+
+def test__dag_parent__properties():
+    inputs = {"a": ParameterUsage(name="a")}
+    node_names_by_id = {"1": "x", "2": "y"}
+
+    dag_parent = DAGParent(
+        inputs=inputs,
+        node_names_by_id=node_names_by_id,
+    )
+
+    assert dag_parent.inputs == inputs
+    assert dag_parent.node_names_by_id == node_names_by_id
+
+
+def test__dag_parent__representation():
+    dag_parent = DAGParent(
+        inputs={"a": ParameterUsage(name="a")},
+        node_names_by_id={"1": "x", "2": "y"},
+    )
+    assert (
+        repr(dag_parent)
+        == f"DAGParent(inputs={repr(dag_parent.inputs)}, node_names_by_id={repr(dag_parent.node_names_by_id)})"
+    )

--- a/tests/dsl/test_dsl.py
+++ b/tests/dsl/test_dsl.py
@@ -57,17 +57,3 @@ def test__dag__as_decorator_with_overrides():
         node_type=NodeType.DAG,
         runtime_options=runtime_options,
     )
-
-
-def test__dag__with_default_value():
-    @dsl.task()
-    def f(a, b=2):
-        return a + b
-
-    @dsl.DAG()
-    def d(x=3):
-        return f(x)
-
-    dag = build(d)
-
-    assert invoke(dag) == 5

--- a/tests/dsl/test_dsl.py
+++ b/tests/dsl/test_dsl.py
@@ -68,4 +68,6 @@ def test__dag__with_default_value():
     def d(x=3):
         return f(x)
 
-    assert invoke(build(d)) == 5
+    dag = build(d)
+
+    assert invoke(dag) == 5

--- a/tests/dsl/test_dsl.py
+++ b/tests/dsl/test_dsl.py
@@ -1,7 +1,9 @@
 import dagger.dsl.dsl as dsl
+from dagger.dsl import build
 from dagger.dsl.node_invocation_recorder import NodeInvocationRecorder
 from dagger.dsl.node_invocations import NodeType
 from dagger.dsl.node_output_serializer import NodeOutputSerializer
+from dagger.runtime.cli import invoke
 from dagger.serializer import AsPickle
 
 
@@ -55,3 +57,15 @@ def test__dag__as_decorator_with_overrides():
         node_type=NodeType.DAG,
         runtime_options=runtime_options,
     )
+
+
+def test__dag__with_default_value():
+    @dsl.task()
+    def f(a, b=2):
+        return a + b
+
+    @dsl.DAG()
+    def d(x=3):
+        return f(x)
+
+    assert invoke(build(d)) == 5

--- a/tests/dsl/test_dsl.py
+++ b/tests/dsl/test_dsl.py
@@ -1,9 +1,7 @@
 import dagger.dsl.dsl as dsl
-from dagger.dsl import build
 from dagger.dsl.node_invocation_recorder import NodeInvocationRecorder
 from dagger.dsl.node_invocations import NodeType
 from dagger.dsl.node_output_serializer import NodeOutputSerializer
-from dagger.runtime.cli import invoke
 from dagger.serializer import AsPickle
 
 

--- a/tests/dsl/test_parameter_usage.py
+++ b/tests/dsl/test_parameter_usage.py
@@ -32,4 +32,4 @@ def test__parameter_usage__is_not_iterable():
 def test__parameter_usage__representation():
     serializer = AsPickle()
     param = ParameterUsage(name="my-name", serializer=serializer)
-    assert repr(param) == f"ParameterUsage(name=my-name, serializer={serializer})"
+    assert repr(param) == f"ParameterUsage(name=my-name, default_value='None', serializer={serializer})"

--- a/tests/dsl/test_parameter_usage.py
+++ b/tests/dsl/test_parameter_usage.py
@@ -34,5 +34,5 @@ def test__parameter_usage__representation():
     param = ParameterUsage(name="my-name", serializer=serializer)
     assert (
         repr(param)
-        == f"ParameterUsage(name=my-name, default_value='None', serializer={serializer})"
+        == f"ParameterUsage(name=my-name, default_value='EmptyDefaultValue', serializer={serializer})"
     )

--- a/tests/dsl/test_parameter_usage.py
+++ b/tests/dsl/test_parameter_usage.py
@@ -36,3 +36,8 @@ def test__parameter_usage__representation():
         repr(param)
         == f"ParameterUsage(name=my-name, default_value='EmptyDefaultValue', serializer={serializer})"
     )
+
+
+def test__parameter_usage__default_value():
+    param = ParameterUsage(name="my-name", default_value=10)
+    assert param.default_value == 10

--- a/tests/dsl/test_parameter_usage.py
+++ b/tests/dsl/test_parameter_usage.py
@@ -32,4 +32,7 @@ def test__parameter_usage__is_not_iterable():
 def test__parameter_usage__representation():
     serializer = AsPickle()
     param = ParameterUsage(name="my-name", serializer=serializer)
-    assert repr(param) == f"ParameterUsage(name=my-name, default_value='None', serializer={serializer})"
+    assert (
+        repr(param)
+        == f"ParameterUsage(name=my-name, default_value='None', serializer={serializer})"
+    )

--- a/tests/dsl/test_parameter_usage.py
+++ b/tests/dsl/test_parameter_usage.py
@@ -1,6 +1,7 @@
 import pytest
 
 from dagger.dsl.parameter_usage import ParameterUsage
+from dagger.input.empty_default_value import EmptyDefaultValue
 from dagger.serializer import AsPickle, DefaultSerializer
 
 
@@ -8,12 +9,14 @@ def test__parameter_usage__default_properties():
     param = ParameterUsage(name="my-name")
     assert param.name == "my-name"
     assert param.serializer == DefaultSerializer
+    assert param.default_value == EmptyDefaultValue()
 
 
 def test__parameter_usage__properties():
-    param = ParameterUsage(name="my-name", serializer=AsPickle())
+    param = ParameterUsage(name="my-name", serializer=AsPickle(), default_value=10)
     assert param.name == "my-name"
     assert param.serializer == AsPickle()
+    assert param.default_value == 10
 
 
 def test__parameter_usage__is_not_iterable():

--- a/tests/input/custom_serializer.py
+++ b/tests/input/custom_serializer.py
@@ -1,19 +1,19 @@
 # noqa
-from dagger import Serializer
+from typing import Any, BinaryIO
 
 
-class CustomSerializer(Serializer):
+class CustomSerializer:
     """Custom serializer implementation to test the injection of different serialization strategies to an input."""
 
     @property
     def extension(self) -> str:  # noqa
         return "ext"
+    
+    def serialize(self, value: Any, writer: BinaryIO):  # noqa
+        raise NotImplementedError()
 
-    def serialize(self, value: str) -> bytes:  # noqa
-        return b"serialized"
-
-    def deserialize(self, serialized_value: bytes) -> str:  # noqa
-        return "deserialized"
+    def deserialize(self, reader: BinaryIO) -> Any:   # noqa
+        raise NotImplementedError()
 
     def __repr__(self) -> str:  # noqa
         return "CustomSerializerInstance"

--- a/tests/input/custom_serializer.py
+++ b/tests/input/custom_serializer.py
@@ -8,11 +8,11 @@ class CustomSerializer:
     @property
     def extension(self) -> str:  # noqa
         return "ext"
-    
+
     def serialize(self, value: Any, writer: BinaryIO):  # noqa
         raise NotImplementedError()
 
-    def deserialize(self, reader: BinaryIO) -> Any:   # noqa
+    def deserialize(self, reader: BinaryIO) -> Any:  # noqa
         raise NotImplementedError()
 
     def __repr__(self) -> str:  # noqa

--- a/tests/input/custom_serializer.py
+++ b/tests/input/custom_serializer.py
@@ -1,7 +1,8 @@
 # noqa
+from dagger import Serializer
 
 
-class CustomSerializer:
+class CustomSerializer(Serializer):
     """Custom serializer implementation to test the injection of different serialization strategies to an input."""
 
     @property

--- a/tests/input/test_from_param.py
+++ b/tests/input/test_from_param.py
@@ -33,4 +33,7 @@ def test__with_overridden_name():
 def test__representation():
     serializer = CustomSerializer()
     input_ = FromParam("my-param", serializer=serializer)
-    assert repr(input_) == f"FromParam(name=my-param, default_value='None', serializer={repr(serializer)})"
+    assert (
+        repr(input_)
+        == f"FromParam(name=my-param, default_value='None', serializer={repr(serializer)})"
+    )

--- a/tests/input/test_from_param.py
+++ b/tests/input/test_from_param.py
@@ -37,3 +37,8 @@ def test__representation():
         repr(input_)
         == f"FromParam(name=my-param, default_value='EmptyDefaultValue', serializer={repr(serializer)})"
     )
+
+
+def test__with_default_value():
+    input_ = FromParam(default_value=10)
+    assert input_.default_value == 10

--- a/tests/input/test_from_param.py
+++ b/tests/input/test_from_param.py
@@ -1,3 +1,4 @@
+from dagger.input.empty_default_value import EmptyDefaultValue
 from dagger.input.from_param import FromParam
 from dagger.input.protocol import Input
 from dagger.serializer import DefaultSerializer
@@ -30,6 +31,18 @@ def test__with_overridden_name():
     assert input_.name == name
 
 
+def test__with_default_value():
+    input_ = FromParam(default_value=10)
+    assert input_.has_default_value()
+    assert input_.default_value == 10
+
+
+def test__without_default_value():
+    input_ = FromParam()
+    assert not input_.has_default_value()
+    assert isinstance(input_.default_value, EmptyDefaultValue)
+
+
 def test__representation():
     serializer = CustomSerializer()
     input_ = FromParam("my-param", serializer=serializer)
@@ -37,8 +50,3 @@ def test__representation():
         repr(input_)
         == f"FromParam(name=my-param, default_value='EmptyDefaultValue', serializer={repr(serializer)})"
     )
-
-
-def test__with_default_value():
-    input_ = FromParam(default_value=10)
-    assert input_.default_value == 10

--- a/tests/input/test_from_param.py
+++ b/tests/input/test_from_param.py
@@ -35,5 +35,5 @@ def test__representation():
     input_ = FromParam("my-param", serializer=serializer)
     assert (
         repr(input_)
-        == f"FromParam(name=my-param, default_value='None', serializer={repr(serializer)})"
+        == f"FromParam(name=my-param, default_value='EmptyDefaultValue', serializer={repr(serializer)})"
     )

--- a/tests/input/test_from_param.py
+++ b/tests/input/test_from_param.py
@@ -33,4 +33,4 @@ def test__with_overridden_name():
 def test__representation():
     serializer = CustomSerializer()
     input_ = FromParam("my-param", serializer=serializer)
-    assert repr(input_) == f"FromParam(name=my-param, serializer={repr(serializer)})"
+    assert repr(input_) == f"FromParam(name=my-param, default_value='None', serializer={repr(serializer)})"

--- a/tests/input/test_validators.py
+++ b/tests/input/test_validators.py
@@ -1,6 +1,12 @@
+import warnings
+
 import pytest
 
-from dagger.input.validators import validate_name
+from dagger.input import FromNodeOutput, FromParam, validate_name, validate_parameters
+
+#
+# validate_parameters
+#
 
 
 def test__validate_name__with_valid_names():
@@ -33,3 +39,97 @@ def test__validate_name__with_invalid_names():
             str(e.value)
             == f"'{name}' is not a valid name for an input. Inputs must comply with the regex ^[a-zA-Z0-9][a-zA-Z0-9-_]{{0,63}}$"
         )
+
+
+#
+# validate_parameters
+#
+
+
+def test__validate_parameters__when_params_match_inputs():
+    validate_parameters(
+        inputs={
+            "a": FromParam(),
+            "b": FromNodeOutput("n", "o"),
+        },
+        params={
+            "a": 1,
+            "b": "2",
+        },
+    )
+    # We are testing there are no exceptions raised as a result of calling the validator
+
+
+def test__validate_parameters__when_input_is_missing():
+    with pytest.raises(ValueError) as e:
+        validate_parameters(
+            inputs={
+                "c": FromParam(),
+                "a": FromParam(),
+                "b": FromNodeOutput("n", "o"),
+            },
+            params={
+                "c": 1,
+                "a": 1,
+            },
+        )
+
+    assert (
+        str(e.value)
+        == "The parameters supplied to this node were supposed to contain the "
+        "following parameters: ['a', 'b', 'c']. However, only the following "
+        "parameters were actually supplied: ['a', 'c']. We are missing: ['b']."
+    )
+
+
+def test__validate_parameters__when_param_is_superfluous():
+    with warnings.catch_warnings(record=True) as w:
+        validate_parameters(
+            inputs={
+                "c": FromParam(),
+                "a": FromParam(),
+            },
+            params={
+                "z": 1,
+                "a": 1,
+                "c": 1,
+                "y": 1,
+            },
+        )
+        assert len(w) == 1
+        assert (
+            str(w[0].message)
+            == "The following parameters were supplied to this node, but are not "
+            "necessary: ['y', 'z']"
+        )
+
+
+def test__validate_parameters__if_superfluous_params_warns():
+    # given
+    inputs = {"a": FromParam("a")}
+    params = {"a": 1, "b": 2}
+    # when
+    with pytest.warns(Warning) as record:
+        validate_parameters(inputs, params)
+        if not record:
+            pytest.fail("Expected a warning!")
+    # then
+    # check that only one warning was raised
+    assert len(record) == 1
+    # check that the message matches
+    assert (
+        record[0].message.args[0] == "The following parameters were supplied to this "
+        "node, but are not necessary: ['b']"
+    )
+
+
+def test__validate_parameters__no_superfluous_params_does_not_warn():
+    # given
+    inputs = {"a": FromParam("a"), "b": FromParam("b", 2), "c": FromParam("c", 3)}
+    params = {"a": 1, "b": 4}
+    # when
+    with pytest.warns(None) as record:
+        validate_parameters(inputs, params)
+
+    # check no warning was raised
+    assert len(record) == 0

--- a/tests/input/test_validators.py
+++ b/tests/input/test_validators.py
@@ -2,7 +2,13 @@ import warnings
 
 import pytest
 
-from dagger.input import FromNodeOutput, FromParam, validate_name, validate_parameters
+from dagger.input import (
+    FromNodeOutput,
+    FromParam,
+    filter_not_required_inputs,
+    validate_name,
+    validate_parameters,
+)
 
 #
 # validate_parameters
@@ -133,3 +139,17 @@ def test__validate_parameters__no_superfluous_params_does_not_warn():
 
     # check no warning was raised
     assert len(record) == 0
+
+
+#
+# filter_not_required_inputs
+#
+
+
+def test__filter_not_required_inputs__only_required_input_is_returned():
+    # given
+    inputs = {"a": FromParam("a"), "b": FromParam("b", 2), "c": FromParam("c", 3)}
+    # when
+    required_inputs = filter_not_required_inputs(inputs)
+    # then
+    assert required_inputs == {"a"}

--- a/tests/runtime/argo/test_workflow_spec.py
+++ b/tests/runtime/argo/test_workflow_spec.py
@@ -223,7 +223,7 @@ def test__workflow_spec__with_invalid_parameters():
 
     assert (
         str(e.value)
-        == "The parameters supplied to this DAG were supposed to contain the following parameters: ['x']. However, only the following parameters were actually supplied: []. We are missing: ['x']."
+        == "The parameters supplied to this node were supposed to contain the following parameters: ['x']. However, only the following parameters were actually supplied: []. We are missing: ['x']."
     )
 
 

--- a/tests/runtime/argo/test_workflow_spec.py
+++ b/tests/runtime/argo/test_workflow_spec.py
@@ -227,6 +227,29 @@ def test__workflow_spec__with_invalid_parameters():
     )
 
 
+def test__workflow_spec__when_dag_has_default_inputs():
+    workflow = Workflow(
+        container_image="my-image",
+        container_entrypoint_to_dag_cli=["my", "dag", "entrypoint"],
+        params={"a": 0},
+    )
+
+    dag = DAG(
+        inputs=dict(
+            a=FromParam(),
+            b=FromParam(default_value=2),
+            c=FromParam(default_value=3),
+        ),
+        nodes=dict(f=Task(lambda: 1)),
+    )
+
+    spec = workflow_spec(dag, workflow)
+
+    assert {"name": "a", "value": 0} in spec["arguments"]["parameters"]
+    assert {"name": "b", "value": 2} in spec["arguments"]["parameters"]
+    assert {"name": "c", "value": 3} in spec["arguments"]["parameters"]
+
+
 def test__workflow_spec__with_template_overrides_that_affect_essential_attributes__fails():
     dag = DAG(
         {

--- a/tests/runtime/cli/test_cli.py
+++ b/tests/runtime/cli/test_cli.py
@@ -62,7 +62,7 @@ def test__invoke__whole_dag():
             assert f.read() == b"64"
 
 
-def test__invoke_dag__with_default_values():
+def test__invoke_dag__overriding_default_value():
     dag = DAG(
         nodes=dict(
             square=Task(
@@ -97,7 +97,7 @@ def test__invoke_dag__with_default_values():
             assert f.read() == b"8"
 
 
-def test__invoke_dag__using_non_default_when_default_is_defined():
+def test__invoke_dag__using_default():
     dag = DAG(
         nodes=dict(
             square=Task(

--- a/tests/runtime/cli/test_cli.py
+++ b/tests/runtime/cli/test_cli.py
@@ -403,3 +403,9 @@ def test__invoke__node_with_partitioned_input():
 
         with open(together_output, "rb") as f:
             assert f.read() == b"[1, 2, 3]"
+
+
+# test dag with default
+
+# test dag with value overriding default
+

--- a/tests/runtime/cli/test_cli.py
+++ b/tests/runtime/cli/test_cli.py
@@ -408,4 +408,3 @@ def test__invoke__node_with_partitioned_input():
 # test dag with default
 
 # test dag with value overriding default
-

--- a/tests/runtime/cli/test_cli.py
+++ b/tests/runtime/cli/test_cli.py
@@ -62,6 +62,71 @@ def test__invoke__whole_dag():
             assert f.read() == b"64"
 
 
+def test__invoke_dag__with_default_values():
+    dag = DAG(
+        nodes=dict(
+            square=Task(
+                lambda x: x ** 3,
+                inputs=dict(x=FromParam("x", 3)),
+                outputs=dict(x_squared=FromReturnValue()),
+            ),
+        ),
+        inputs=dict(x=FromParam("x", 3)),
+        outputs=dict(x_squared=FromNodeOutput("square", "x_squared")),
+    )
+
+    with tempfile.TemporaryDirectory() as tmp:
+        x_input = os.path.join(tmp, "x_input")
+        x_output = os.path.join(tmp, "x_output")
+
+        with open(x_input, "wb") as f:
+            f.write(b"2")
+
+        invoke(
+            dag,
+            argv=itertools.chain(
+                *[
+                    ["--input", "x", x_input],
+                    ["--node-name", "square"],
+                    ["--output", "x_squared", x_output],
+                ]
+            ),
+        )
+
+        with open(x_output, "rb") as f:
+            assert f.read() == b"8"
+
+
+def test__invoke_dag__using_non_default_when_default_is_defined():
+    dag = DAG(
+        nodes=dict(
+            square=Task(
+                lambda x: x ** 2,
+                inputs=dict(x=FromParam("x", 3)),
+                outputs=dict(x_squared=FromReturnValue()),
+            ),
+        ),
+        inputs=dict(x=FromParam("x", 3)),
+        outputs=dict(x_squared=FromNodeOutput("square", "x_squared")),
+    )
+
+    with tempfile.TemporaryDirectory() as tmp:
+        x_output = os.path.join(tmp, "x_output")
+
+        invoke(
+            dag,
+            argv=itertools.chain(
+                *[
+                    ["--node-name", "square"],
+                    ["--output", "x_squared", x_output],
+                ]
+            ),
+        )
+
+        with open(x_output, "rb") as f:
+            assert f.read() == b"9"
+
+
 def test__invoke__selecting_a_node_that_does_not_exist():
     dag = DAG(
         {

--- a/tests/runtime/local/test_dag.py
+++ b/tests/runtime/local/test_dag.py
@@ -244,7 +244,7 @@ def test__invoke_dag__using_default_value():
     )
     with tempfile.TemporaryDirectory() as tmp:
         res = invoke_dag(dag, params={}, output_path=tmp)
-        assert deserialized_outputs(res) == {'return_value': 3}
+        assert deserialized_outputs(res) == {"return_value": 3}
 
 
 def test__invoke_dag__using_a_value_instead_of_default_value():
@@ -261,7 +261,7 @@ def test__invoke_dag__using_a_value_instead_of_default_value():
     )
     with tempfile.TemporaryDirectory() as tmp:
         res = invoke_dag(dag, params={"x": 5}, output_path=tmp)
-        assert deserialized_outputs(res) == {'return_value': 5}
+        assert deserialized_outputs(res) == {"return_value": 5}
 
 
 def test__invoke_dag__using_none_instead_of_default_value():
@@ -278,5 +278,4 @@ def test__invoke_dag__using_none_instead_of_default_value():
     )
     with tempfile.TemporaryDirectory() as tmp:
         res = invoke_dag(dag, params={"x": None}, output_path=tmp)
-        assert deserialized_outputs(res) == {'return_value': 0}
-
+        assert deserialized_outputs(res) == {"return_value": 0}

--- a/tests/runtime/local/test_dag.py
+++ b/tests/runtime/local/test_dag.py
@@ -320,6 +320,7 @@ def test__invoke_dag__with_two_default_values_one_using_other_value(multiply_fun
 # validate_parameters
 #
 
+
 def test__validate_parameters__if_superfluous_params_warns():
     # given
     inputs = {"a": FromParam("a")}
@@ -333,7 +334,10 @@ def test__validate_parameters__if_superfluous_params_warns():
     # check that only one warning was raised
     assert len(record) == 1
     # check that the message matches
-    assert record[0].message.args[0] == "The following parameters were supplied to this node, but are not necessary: ['b']"
+    assert (
+        record[0].message.args[0]
+        == "The following parameters were supplied to this node, but are not necessary: ['b']"
+    )
 
 
 def test__validate_parameters__no_superfluous_params_does_not_warn():
@@ -346,6 +350,11 @@ def test__validate_parameters__no_superfluous_params_does_not_warn():
 
     # check no warning was raised
     assert len(record) == 0
+
+
+#
+# fixtures
+#
 
 
 @pytest.fixture()

--- a/tests/runtime/local/test_dag.py
+++ b/tests/runtime/local/test_dag.py
@@ -319,4 +319,5 @@ def test__invoke_dag__with_two_default_values_one_using_other_value(multiply_fun
 def multiply_function():
     def f(x, y):
         return x * y
+
     return f

--- a/tests/runtime/local/test_dag.py
+++ b/tests/runtime/local/test_dag.py
@@ -1,9 +1,8 @@
 import tempfile
-import warnings
 
 import pytest
 
-from dagger.dag import DAG, validate_parameters
+from dagger.dag import DAG
 from dagger.input import FromNodeOutput, FromParam
 from dagger.output import FromKey, FromReturnValue
 from dagger.runtime.local.dag import invoke_dag

--- a/tests/runtime/local/test_dag.py
+++ b/tests/runtime/local/test_dag.py
@@ -230,7 +230,53 @@ def test__invoke_dag__with_partitions_but_invalid_outputs():
     )
 
 
-# test using default value
+def test__invoke_dag__using_default_value():
+    dag = DAG(
+        inputs={"x": FromParam("x", 3)},
+        outputs={"return_value": FromNodeOutput("f", "return_value")},
+        nodes={
+            "f": Task(
+                lambda a: a,
+                inputs={"a": FromParam("x", 3)},
+                outputs={"return_value": FromReturnValue()},
+            )
+        },
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        res = invoke_dag(dag, params={}, output_path=tmp)
+        assert deserialized_outputs(res) == {'return_value': 3}
 
-# test using value instead of default
+
+def test__invoke_dag__using_a_value_instead_of_default_value():
+    dag = DAG(
+        inputs={"x": FromParam("x", 3)},
+        outputs={"return_value": FromNodeOutput("f", "return_value")},
+        nodes={
+            "f": Task(
+                lambda a: a,
+                inputs={"a": FromParam("x", 3)},
+                outputs={"return_value": FromReturnValue()},
+            )
+        },
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        res = invoke_dag(dag, params={"x": 5}, output_path=tmp)
+        assert deserialized_outputs(res) == {'return_value': 5}
+
+
+def test__invoke_dag__using_none_instead_of_default_value():
+    dag = DAG(
+        inputs={"x": FromParam("x", 3)},
+        outputs={"return_value": FromNodeOutput("f", "return_value")},
+        nodes={
+            "f": Task(
+                lambda a: 0 if a is None else a,
+                inputs={"a": FromParam("x", 3)},
+                outputs={"return_value": FromReturnValue()},
+            )
+        },
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        res = invoke_dag(dag, params={"x": None}, output_path=tmp)
+        assert deserialized_outputs(res) == {'return_value': 0}
 

--- a/tests/runtime/local/test_dag.py
+++ b/tests/runtime/local/test_dag.py
@@ -55,7 +55,7 @@ def test__invoke_dag__with_missing_input_parameter():
 
     assert (
         str(e.value)
-        == "The parameters supplied to this DAG were supposed to contain the following parameters: ['a']. However, only the following parameters were actually supplied: ['y']. We are missing: ['a']."
+        == "The parameters supplied to this node were supposed to contain the following parameters: ['a']. However, only the following parameters were actually supplied: ['y']. We are missing: ['a']."
     )
 
 
@@ -228,3 +228,9 @@ def test__invoke_dag__with_partitions_but_invalid_outputs():
         str(e.value)
         == "Error when invoking node 'generate-single-number'. We encountered the following error while attempting to serialize the results of this task: Output 'n' was declared as a partitioned output, but the return value was not an iterable (instead, it was of type 'int'). Partitioned outputs should be iterables of values (e.g. lists or sets). Each value in the iterable must be serializable with the serializer defined in the output."
     )
+
+
+# test using default value
+
+# test using value instead of default
+

--- a/tests/runtime/local/test_task.py
+++ b/tests/runtime/local/test_task.py
@@ -239,8 +239,11 @@ def test__filter_inputs__with_truthy_params():
 
 
 def test__filter_inputs__with_superfluous_params():
-    filtered_inputs = _filter_inputs(inputs={"x": FromParam()}, params={"x": 3, "y": 4})
-    assert filtered_inputs == {"x": 3}
+    filtered_inputs = _filter_inputs(
+        inputs={"x": FromParam(), "y": FromParam(default_value=2)},
+        params={"x": 3, "z": 10},
+    )
+    assert filtered_inputs == {"x": 3, "y": 2}
 
 
 def test__filter_inputs__with_falsy_params():

--- a/tests/runtime/local/test_task.py
+++ b/tests/runtime/local/test_task.py
@@ -234,16 +234,12 @@ def test__invoke_task__overriding_default_value():
 def test__filter_inputs__with_truthy_params():
     cases = [True, 1, [1, 2], {1, 2}, {"a": 1, "b": 2}]
     for case in cases:
-        filtered_inputs = _filter_inputs(
-            inputs={"x": FromParam()}, params={"x": case}
-        )
+        filtered_inputs = _filter_inputs(inputs={"x": FromParam()}, params={"x": case})
         assert filtered_inputs == {"x": case}
 
 
 def test__filter_inputs__with_superfluous_params():
-    filtered_inputs = _filter_inputs(
-        inputs={"x": FromParam()}, params={"x": 3, "y": 4}
-    )
+    filtered_inputs = _filter_inputs(inputs={"x": FromParam()}, params={"x": 3, "y": 4})
     assert filtered_inputs == {"x": 3}
 
 

--- a/tests/runtime/local/test_task.py
+++ b/tests/runtime/local/test_task.py
@@ -232,15 +232,17 @@ def test__invoke_task__overriding_default_value():
 
 
 def test__filter_inputs__with_truthy_params():
-    filtered_inputs = _filter_inputs(
-        inputs={"x": FromParam(name=None)}, params={"x": 3}
-    )
-    assert filtered_inputs == {"x": 3}
+    cases = [True, 1, [1, 2], {1, 2}, {"a": 1, "b": 2}]
+    for case in cases:
+        filtered_inputs = _filter_inputs(
+            inputs={"x": FromParam()}, params={"x": case}
+        )
+        assert filtered_inputs == {"x": case}
 
 
 def test__filter_inputs__with_superfluous_params():
     filtered_inputs = _filter_inputs(
-        inputs={"x": FromParam(name=None)}, params={"x": 3, "y": 4}
+        inputs={"x": FromParam()}, params={"x": 3, "y": 4}
     )
     assert filtered_inputs == {"x": 3}
 
@@ -249,21 +251,22 @@ def test__filter_inputs__with_falsy_params():
     cases = [None, [], False, {}, ""]
     for case in cases:
         filtered_inputs = _filter_inputs(
-            inputs={"x": FromParam(name=None, default_value=10)},
+            inputs={"x": FromParam(default_value=10)},
             params={"x": case, "y": 4},
         )
         assert filtered_inputs == {"x": case}
 
 
 def test__filter_inputs__overriding_default_value():
+
     filtered_inputs = _filter_inputs(
-        inputs={"x": FromParam(name=None, default_value=3)}, params={"x": 5}
+        inputs={"x": FromParam(default_value=3)}, params={"x": 5}
     )
     assert filtered_inputs == {"x": 5}
 
 
 def test__filter_inputs__using_default_value():
     filtered_inputs = _filter_inputs(
-        inputs={"x": FromParam(name=None, default_value=3)}, params={}
+        inputs={"x": FromParam(default_value=3)}, params={}
     )
     assert filtered_inputs == {"x": 3}

--- a/tests/runtime/local/test_task.py
+++ b/tests/runtime/local/test_task.py
@@ -7,7 +7,7 @@ import pytest
 from dagger.input import FromParam
 from dagger.output import FromKey, FromReturnValue
 from dagger.runtime.local.output import deserialized_outputs
-from dagger.runtime.local.task import invoke_task, _filter_inputs
+from dagger.runtime.local.task import _filter_inputs, invoke_task
 from dagger.serializer import AsPickle, SerializationError
 from dagger.task import Task
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Please fill in the following template -->

#### What this PR does / why do we need it: provides support to default values for parameters of DAGs and Tasks

#### Which issue(s) does this PR fix:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #35 

#### Release Notes

<!--
Write a release note to be included with the release of the next version
-->
```release-note
- Support default values in DAGs and tasks
- Bugfix for which nested DAGs could not get hardcoded values injected into them
- Documentation update 
- API change: remove validate_parameters from the dagger.dag module
```

#### What type of changes to the API does this change introduce?

MAJOR: This PR contains backward-incompatible changes to the API (e.g. a new required argument was added to a public method)

#### Checklist

- [x] I've read the [Contribution Guidelines](https://github.com/larribas/dagger/blob/main/CONTRIBUTING.md)
- [x] Updated the appropriate sections of the documentation.
- [x] I've added automated tests covering all success and error scenarios.

---

Going into more detail, this PR addresses the following aspects.

## Introducing default values in the Core Data structures

Changing FromParam to store `default_value` in the constructor,

```python
class FromParam:
    """Input retrieved from the parameters passed to the parent node."""

    def __init__(
        self,
        name: Optional[str] = None,
        default_value: Union[
            EmptyDefaultValue, JSONSerializableType
        ] = EmptyDefaultValue(),
        serializer: Serializer = DefaultSerializer,
    ):
``` 

Adding a new data structure, `EmptyDefaultValue`, to differentiate between the default value `None` and no default value,

```python
class EmptyDefaultValue:
    """Marker object that represents a parameter without default value.
    This representation is needed to distinguish no default from a None default value.
    """
```

## Changing the DSL so that default values are persisted

For instance, the following dags written in imperative and declarative ways are equivalent,

```python
@dsl.task()
def f(a):
    return a

@dsl.DAG()
def dag(x=3):
    return f(x)

verify_dags_are_equivalent(
    dsl.build(dag),
    DAG(
        inputs={"x": FromParam("x", default_value=3)},
        outputs={"return_value": FromNodeOutput("f", "return_value")},
        nodes={
            "f": Task(
                f.func,
                inputs={"a": FromParam("x")},
                outputs={"return_value": FromReturnValue()},
            )
        },
    )
)
```

## Using hardcoded values in the DSL

Users can pass hardcoded values as a parameter to a DAG's task. For instance:

```python
@dsl.DAG()
def dag(a):
  f(a, 2)
```

Prior to #53, the way we achieved this behavior was by wrapping the function `f` into a lambda **kwargs: original_f(**hardcoded_values, **kwargs)`.

This made the output less straightforward (the `func` attribute was generated dynamically) and therefore harder to test.

More importantly, it presented a bug wherein nested DAGs could not get hardcoded values injected into them, and this was not tested nor documented by the library.

After #53, we are taking advantage of the semantics of `FromParam(default_value=hardcoded_value)` to achieve this behavior. This makes the implementation and tests simpler, and eliminates the aforementioned bug.


## Adaptation of the Argo runtime to default values in DAGs

This PR adds code to the Argo runtime so that when we have

```python
workflow = Workflow(
    container_image="my-image",
    container_entrypoint_to_dag_cli=["my", "dag", "entrypoint"],
    params={"a": 0},
)

dag = DAG(
    inputs=dict(
        a=FromParam(),
        b=FromParam(default_value=2),
        c=FromParam(default_value=3),
    ),
    nodes=dict(f=Task(lambda: 1)),
)

spec = workflow_spec(dag, workflow)
```

The spec's `arguments.parameters` list contains `a=0, b=2, c=3`.
